### PR TITLE
Allow connection selection on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoEmqutiti
 
-GoEmqutiti is a terminal based MQTT client built with [Bubble Tea](https://github.com/charmbracelet/bubbletea). It connects to a broker defined in `~/.emqutiti/config.toml` and provides a simple interface for publishing and subscribing to messages.
+GoEmqutiti is a terminal based MQTT client built with [Bubble Tea](https://github.com/charmbracelet/bubbletea). It loads connection profiles from `~/.emqutiti/config.toml` and lets you choose which broker to connect to at runtime.
 
 ## Installation
 
@@ -21,7 +21,7 @@ This will produce a `goemqutiti` binary in the current directory.
 
 ## Usage
 
-Run the built binary (or use `go run .`) to start the TUI application. The UI is fullscreen and features a colorful connection manager accessible with the `m` key. Profiles expose all common connection options inspired by the EMQX MQTT client:
+Run the built binary (or use `go run .`) to start the TUI application. On startup the connection manager is shown so you can select which profile to use. The manager can also be opened at any time with the `m` key. Profiles expose all common connection options inspired by the EMQX MQTT client:
 
 ```bash
 ./goemqutiti

--- a/main.go
+++ b/main.go
@@ -60,40 +60,10 @@ func main() {
 		log.Fatalf("Failed to load configuration: %v", err)
 	}
 
-	// Find the default profile
-	var profile Profile
-	for _, p := range config.Profiles {
-		if p.Name == config.DefaultProfileName {
-			profile = p
-			break
-		}
-	}
-
-	if profile.Name == "" {
-		log.Fatalf("Default profile '%s' not found", config.DefaultProfileName)
-	}
-
-	// Override password with environment variable if set
-	envPassword := os.Getenv("MQTT_PASSWORD")
-	var password string
-	if envPassword != "" {
-		password = envPassword
-	} else {
-		password = profile.Password // Already []byte, no conversion needed
-	}
-
-	// Initialize MQTT client
-	profile.Password = password
-	mqttClient, err := NewMQTTClient(profile)
-	if err != nil {
-		log.Fatalf("Failed to connect to MQTT broker: %v", err)
-	}
-	defer mqttClient.Client.Disconnect(250)
-
-	// Start Bubble Tea UI
+	// Start Bubble Tea UI without connecting. The user can choose a profile
+	// from the connection manager once the program starts.
 	initial := initialModel(config)
-	brokerURL := fmt.Sprintf("%s://%s:%d", profile.Schema, profile.Host, profile.Port)
-	initial.connection = "Connected to " + brokerURL
+	initial.mode = modeConnections
 	p := tea.NewProgram(initial)
 	if _, err := p.Run(); err != nil {
 		log.Fatalf("Error running program: %v", err)


### PR DESCRIPTION
## Summary
- start TUI without an automatic connection
- choose a profile from the connection manager with `Enter`
- describe the new behaviour in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883b3ddf83083249dc919d6950e4119