### PR TITLE
Improve input and exit behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ Passwords can be stored securely using the operating system keyring. You may als
 
 In the interface:
 
-- **Tab** switches between the topic and message fields.
-- **Enter** subscribes to a topic the first time and publishes messages afterwards.
+ - **Tab** switches between the topic and message fields.
+ - **Enter** subscribes to a topic when the topic field is focused.
+ - **Ctrl+S** publishes the message currently in the editor.
 - **Ctrl+M** opens the connection manager where you can add, edit or delete MQTT profiles.
 - **Ctrl+T** manages subscribed topics.
 - **Ctrl+P** manages stored payloads.

--- a/connections.go
+++ b/connections.go
@@ -58,6 +58,7 @@ func NewConnectionsModel() Connections {
 	connectionList.Title = "Connections"
 	// Ensure items are visible by setting a reasonable default size
 	connectionList.SetSize(30, 10)
+	connectionList.DisableQuitKeybindings()
 
 	return Connections{
 		ConnectionsList: connectionList,

--- a/model.go
+++ b/model.go
@@ -143,7 +143,13 @@ func initialModel(conns *Connections) model {
 	hist := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	hist.SetShowStatusBar(false)
 	hist.SetShowPagination(false)
+	hist.DisableQuitKeybindings()
 	statusChan := make(chan string, 10)
+
+	topicsList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	topicsList.DisableQuitKeybindings()
+	payloadList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
+	payloadList.DisableQuitKeybindings()
 
 	return model{
 		history:       hist,
@@ -151,8 +157,8 @@ func initialModel(conns *Connections) model {
 		topicInput:    ti,
 		messageInput:  ta,
 		topics:        []topicItem{},
-		topicsList:    list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0),
-		payloadList:   list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0),
+		topicsList:    topicsList,
+		payloadList:   payloadList,
 		focusIndex:    0,
 		selectedTopic: -1,
 		statusChan:    statusChan,

--- a/update.go
+++ b/update.go
@@ -102,15 +102,8 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 			if m.focusIndex == 2 && len(m.topics) > 0 {
 				m.selectedTopic = (m.selectedTopic + 1) % len(m.topics)
 			}
-		case "enter", " ":
-			if m.focusIndex == 0 {
-				topic := strings.TrimSpace(m.topicInput.Value())
-				if topic != "" {
-					m.topics = append(m.topics, topicItem{title: topic, active: true})
-					m.appendHistory(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
-					m.topicInput.SetValue("")
-				}
-			} else if m.focusIndex == 1 {
+		case "ctrl+s":
+			if m.focusIndex == 1 {
 				payload := m.messageInput.Value()
 				for _, t := range m.topics {
 					if t.active {
@@ -122,6 +115,15 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 					}
 				}
 				m.messageInput.SetValue("")
+			}
+		case "enter":
+			if m.focusIndex == 0 {
+				topic := strings.TrimSpace(m.topicInput.Value())
+				if topic != "" {
+					m.topics = append(m.topics, topicItem{title: topic, active: true})
+					m.appendHistory(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
+					m.topicInput.SetValue("")
+				}
 			} else if m.focusIndex == 2 && m.selectedTopic >= 0 && m.selectedTopic < len(m.topics) {
 				m.topics[m.selectedTopic].active = !m.topics[m.selectedTopic].active
 			}
@@ -152,6 +154,7 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 						items = append(items, topicItem{title: tpc.title, active: tpc.active})
 					}
 					m.topicsList = list.New(items, list.NewDefaultDelegate(), m.width-4, m.height-4)
+					m.topicsList.DisableQuitKeybindings()
 					m.topicsList.Title = "Topics"
 					m.mode = modeTopics
 				case "ctrl+p":
@@ -160,6 +163,7 @@ func (m model) updateClient(msg tea.Msg) (model, tea.Cmd) {
 						items = append(items, payloadItem{topic: topic, payload: payload})
 					}
 					m.payloadList = list.New(items, list.NewDefaultDelegate(), m.width-4, m.height-4)
+					m.payloadList.DisableQuitKeybindings()
 					m.payloadList.Title = "Payloads"
 					m.mode = modePayloads
 				}


### PR DESCRIPTION
## Summary
- allow multi-line message entry by sending messages with `Ctrl+S`
- disable list quit keybindings so `Esc` never quits the app
- keep lists from exiting when viewing topics or payloads
- update documentation with new hotkey

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883f6e2312083249ee8908c22550d52