### PR TITLE
Fix lipgloss deprecations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,3 +17,9 @@ The TUI runs fullscreen with colorful borders. Press `Ctrl+M` to open the connec
 
 ## Maintenance
 Keep `README.md`, `TODO.md`, and `AGENTS.md` in sync when changes are made to the project or development workflow.
+
+## Dependencies
+When adding or updating third-party packages, always consult the latest
+documentation for each dependency to ensure deprecated APIs are avoided.
+Replace outdated calls with the recommended alternatives before committing
+changes.

--- a/styles.go
+++ b/styles.go
@@ -12,9 +12,9 @@ var (
 	cursorStyle  = focusedStyle
 	noCursor     = lipgloss.NewStyle()
 	borderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("63")).Padding(0, 1)
-	greenBorder  = borderStyle.Copy().BorderForeground(lipgloss.Color("34"))
+	greenBorder  = borderStyle.BorderForeground(lipgloss.Color("34"))
 	chipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(lipgloss.Color("63")).Faint(true)
-	chipInactive = chipStyle.Copy().Foreground(lipgloss.Color("240"))
+	chipInactive = chipStyle.Foreground(lipgloss.Color("240"))
 )
 
 func legendBox(content, label string, width int, focused bool) string {

--- a/views.go
+++ b/views.go
@@ -40,7 +40,7 @@ func (m *model) viewClient() string {
 			st = chipInactive
 		}
 		if m.focusIndex == 2 && i == m.selectedTopic {
-			st = st.Copy().BorderForeground(lipgloss.Color("212"))
+			st = st.BorderForeground(lipgloss.Color("212"))
 		}
 		chips = append(chips, st.Render(t.title))
 	}
@@ -82,7 +82,7 @@ func (m model) viewConnections() string {
 	listView := m.connections.ConnectionsList.View()
 	help := "[enter] connect  [a]dd [e]dit [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Copy().Width(m.width - 2).Height(m.height - 2).Render(content)
+	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
 }
 
 func (m model) viewForm() string {
@@ -91,8 +91,8 @@ func (m model) viewForm() string {
 	}
 	listView := m.connections.ConnectionsList.View()
 	formView := m.connForm.View()
-	left := borderStyle.Copy().Width(m.width/2 - 2).Render(listView)
-	right := borderStyle.Copy().Width(m.width/2 - 2).Render(formView)
+	left := borderStyle.Width(m.width/2 - 2).Render(listView)
+	right := borderStyle.Width(m.width/2 - 2).Render(formView)
 	return lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 }
 
@@ -109,14 +109,14 @@ func (m model) viewTopics() string {
 	listView := m.topicsList.View()
 	help := "[space] toggle  [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Copy().Width(m.width - 2).Height(m.height - 2).Render(content)
+	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
 }
 
 func (m model) viewPayloads() string {
 	listView := m.payloadList.View()
 	help := "[enter] load  [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Copy().Width(m.width - 2).Height(m.height - 2).Render(content)
+	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
 }
 
 func (m *model) View() string {


### PR DESCRIPTION
## Summary
- add dependency guidance for staying current with upstream packages
- stop using lipgloss `Copy()` when building styles

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68849ca44790832499e04bfc7e48a78a