### PR TITLE
UI tweaks and persistent state

### DIFF
--- a/historydelegate.go
+++ b/historydelegate.go
@@ -42,7 +42,7 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		align = lipgloss.Right
 	}
 	line1 := lipgloss.PlaceHorizontal(width, align, lipgloss.NewStyle().Foreground(lblColor).Render(label))
-	line2 := lipgloss.NewStyle().Foreground(msgColor).Width(width).Render(hi.payload)
+	line2 := lipgloss.PlaceHorizontal(width, align, lipgloss.NewStyle().Foreground(msgColor).Render(hi.payload))
 	lines := []string{line1, line2}
 	if _, ok := d.m.selectedHistory[index]; ok {
 		for i, l := range lines {

--- a/model.go
+++ b/model.go
@@ -75,7 +75,7 @@ const (
 
 type connectionData struct {
 	Topics   []topicItem
-	Payloads map[string]string
+	Payloads []payloadItem
 }
 
 type focusable interface {
@@ -91,7 +91,7 @@ type model struct {
 	history         list.Model
 	topicInput      textinput.Model
 	messageInput    textarea.Model
-	payloads        map[string]string
+	payloads        []payloadItem
 	topics          []topicItem
 	topicsList      list.Model
 	payloadList     list.Model
@@ -136,7 +136,10 @@ func initialModel(conns *Connections) *model {
 	ta := textarea.New()
 	ta.Placeholder = "Enter Message"
 	ta.CharLimit = 10000
-	ta.Prompt = "> "
+	ta.ShowLineNumbers = false
+	ta.SetPromptFunc(0, func(i int) string {
+		return fmt.Sprintf(">%d ", i+1)
+	})
 	ta.Blur()
 	ta.Cursor.Style = noCursor
 	// Set width once the WindowSizeMsg arrives
@@ -174,10 +177,11 @@ func initialModel(conns *Connections) *model {
 	vp := viewport.New(0, 0)
 
 	order := []string{"topic", "message", "topics", "history"}
+	saved := loadState()
 
 	m := &model{
 		history:         hist,
-		payloads:        make(map[string]string),
+		payloads:        []payloadItem{},
 		topicInput:      ti,
 		messageInput:    ta,
 		topics:          []topicItem{},
@@ -193,7 +197,7 @@ func initialModel(conns *Connections) *model {
 		viewport:        vp,
 		elemPos:         map[string]int{},
 		focusOrder:      order,
-		saved:           make(map[string]connectionData),
+		saved:           saved,
 		selectedHistory: make(map[int]struct{}),
 		selectionAnchor: -1,
 		prevMode:        modeClient,

--- a/state.go
+++ b/state.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+)
+
+// persistedTopic mirrors topicItem for persistence in the config file.
+type persistedTopic struct {
+	Title  string `toml:"title"`
+	Active bool   `toml:"active"`
+}
+
+type persistedPayload struct {
+	Topic   string `toml:"topic"`
+	Payload string `toml:"payload"`
+}
+
+type persistedConn struct {
+	Topics   []persistedTopic   `toml:"topics"`
+	Payloads []persistedPayload `toml:"payloads"`
+}
+
+// userConfig represents the structure stored in config.toml.
+type userConfig struct {
+	DefaultProfileName string                   `toml:"default_profile"`
+	Profiles           []Profile                `toml:"profiles"`
+	Saved              map[string]persistedConn `toml:"saved"`
+}
+
+// loadState retrieves saved topics and payloads from config.toml.
+func loadState() map[string]connectionData {
+	fp, err := DefaultUserConfigFile()
+	if err != nil {
+		return map[string]connectionData{}
+	}
+	var cfg userConfig
+	if _, err := toml.DecodeFile(fp, &cfg); err != nil {
+		return map[string]connectionData{}
+	}
+	out := make(map[string]connectionData)
+	for k, v := range cfg.Saved {
+		var topics []topicItem
+		for _, t := range v.Topics {
+			topics = append(topics, topicItem{title: t.Title, active: t.Active})
+		}
+		var payloads []payloadItem
+		for _, p := range v.Payloads {
+			payloads = append(payloads, payloadItem{topic: p.Topic, payload: p.Payload})
+		}
+		out[k] = connectionData{Topics: topics, Payloads: payloads}
+	}
+	return out
+}
+
+// writeConfig writes the entire configuration back to disk.
+func writeConfig(cfg userConfig) {
+	fp, err := DefaultUserConfigFile()
+	if err != nil {
+		return
+	}
+	os.MkdirAll(filepath.Dir(fp), os.ModePerm)
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(cfg); err != nil {
+		return
+	}
+	os.WriteFile(fp, buf.Bytes(), 0644)
+}
+
+// saveState updates only the Saved section in config.toml.
+func saveState(data map[string]connectionData) {
+	fp, err := DefaultUserConfigFile()
+	if err != nil {
+		return
+	}
+	var cfg userConfig
+	toml.DecodeFile(fp, &cfg) // ignore errors for new files
+	cfg.Saved = make(map[string]persistedConn)
+	for k, v := range data {
+		var topics []persistedTopic
+		for _, t := range v.Topics {
+			topics = append(topics, persistedTopic{Title: t.title, Active: t.active})
+		}
+		var payloads []persistedPayload
+		for _, p := range v.Payloads {
+			payloads = append(payloads, persistedPayload{Topic: p.topic, Payload: p.payload})
+		}
+		cfg.Saved[k] = persistedConn{Topics: topics, Payloads: payloads}
+	}
+	writeConfig(cfg)
+}

--- a/views.go
+++ b/views.go
@@ -41,28 +41,25 @@ func (m *model) viewClient() string {
 		}
 		chips = append(chips, st.Render(t.title))
 	}
-	topicsFocused := m.focusOrder[m.focusIndex] == "topics"
+	topicsFocused := m.focusOrder[m.focusIndex] == "topics" || m.focusOrder[m.focusIndex] == "topic"
 	historyFocused := m.focusOrder[m.focusIndex] == "history"
 
-	topicsBox := legendBox(wrapChips(chips, m.width-4), "Topics", m.width-2, topicsFocused)
+	topicsContent := lipgloss.JoinVertical(lipgloss.Left, m.topicInput.View(), wrapChips(chips, m.width-4))
+	topicsBox := legendBox(topicsContent, "Topics", m.width-2, topicsFocused)
+
+	messageBox := legendBox(m.messageInput.View(), "Message", m.width-2, m.focusIndex == 1)
 
 	messagesBox := legendGreenBox(m.history.View(), "History (Ctrl+C copy)", m.width-2, historyFocused)
 
-	topicBox := legendBox(m.topicInput.View(), "Topic", m.width-2, m.focusIndex == 0)
-	messageBox := legendBox(m.messageInput.View(), "Message", m.width-2, m.focusIndex == 1)
-
-	inputsBox := lipgloss.JoinVertical(lipgloss.Left, topicBox, messageBox)
-
-	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, messagesBox, inputsBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, messageBox, messagesBox)
 
 	y := 1
 	m.elemPos["topics"] = y
-	y += lipgloss.Height(topicsBox)
-	m.elemPos["history"] = y
-	y += lipgloss.Height(messagesBox)
 	m.elemPos["topic"] = y
-	y += lipgloss.Height(topicBox)
+	y += lipgloss.Height(topicsBox)
 	m.elemPos["message"] = y
+	y += lipgloss.Height(messageBox)
+	m.elemPos["history"] = y
 
 	box := lipgloss.NewStyle().Width(m.width).Padding(1, 1).Render(content)
 	m.viewport.SetContent(box)
@@ -98,14 +95,14 @@ func (m model) viewTopics() string {
 	listView := m.topicsList.View()
 	help := "[space] toggle  [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
+	return legendBox(content, "Topics", m.width-2, false)
 }
 
 func (m model) viewPayloads() string {
 	listView := m.payloadList.View()
 	help := "[enter] load  [d]elete  [esc] back"
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	return borderStyle.Width(m.width - 2).Height(m.height - 2).Render(content)
+	return legendBox(content, "Payloads", m.width-2, false)
 }
 
 func (m *model) View() string {


### PR DESCRIPTION
## Summary
- align message text in history view
- merge topic input into the Topics box
- show message editor below topics
- increase history height and shrink textarea prompt
- persist topics and payloads to ~/.emqutiti/config.toml
- label Topics and Payload views in their borders

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6884f56ea2788324b89a98c4842997d0