### PR TITLE
Refactor profile utilities and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,19 @@ scrollable bar on the left.
 
 Future versions may store import settings for quick reuse.
 
+### Headless tracing
+
+Run the program with `--trace <key>` and `--topics <list>` to record messages
+without launching the TUI. Optional `--start` and `--end` values limit the trace
+duration. All times use RFC3339 format.
+
+```bash
+./goemqutiti --trace myrun --topics "sensors/#,devices/+/status" -p local --start 2024-01-01T00:00:00Z --end 2024-01-01T01:00:00Z
+```
+
+Traces are stored in `~/.emqutiti/data/<profile>/traces` and can be inspected
+later.
+
 ## License
 
 This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.

--- a/config/profile.go
+++ b/config/profile.go
@@ -1,0 +1,192 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+	"github.com/zalando/go-keyring"
+)
+
+// Profile defines a broker connection.
+type Profile struct {
+	Name                string `toml:"name"`
+	Schema              string `toml:"schema"`
+	Host                string `toml:"host"`
+	Port                int    `toml:"port"`
+	ClientID            string `toml:"client_id"`
+	Username            string `toml:"username"`
+	Password            string `toml:"password"`
+	FromEnv             bool   `toml:"from_env"`
+	SSL                 bool   `toml:"ssl_tls"`
+	MQTTVersion         string `toml:"mqtt_version"`
+	ConnectTimeout      int    `toml:"connect_timeout"`
+	KeepAlive           int    `toml:"keep_alive"`
+	QoS                 int    `toml:"qos"`
+	AutoReconnect       bool   `toml:"auto_reconnect"`
+	ReconnectPeriod     int    `toml:"reconnect_period"`
+	CleanStart          bool   `toml:"clean_start"`
+	SessionExpiry       int    `toml:"session_expiry_interval"`
+	ReceiveMaximum      int    `toml:"receive_maximum"`
+	MaximumPacketSize   int    `toml:"maximum_packet_size"`
+	TopicAliasMaximum   int    `toml:"topic_alias_maximum"`
+	RequestResponseInfo bool   `toml:"request_response_info"`
+	RequestProblemInfo  bool   `toml:"request_problem_info"`
+	LastWillEnabled     bool   `toml:"last_will_enabled"`
+	LastWillTopic       string `toml:"last_will_topic"`
+	LastWillQos         int    `toml:"last_will_qos"`
+	LastWillRetain      bool   `toml:"last_will_retain"`
+	LastWillPayload     string `toml:"last_will_payload"`
+	RandomIDSuffix      bool   `toml:"random_id_suffix"`
+}
+
+type Config struct {
+	DefaultProfile string    `toml:"default_profile"`
+	Profiles       []Profile `toml:"profiles"`
+}
+
+// DefaultUserConfigFile returns ~/.emqutiti/config.toml.
+func DefaultUserConfigFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".emqutiti", "config.toml"), nil
+}
+
+// RetrievePasswordFromKeyring resolves a keyring:<service>/<user> reference.
+func RetrievePasswordFromKeyring(password string) (string, error) {
+	if !strings.HasPrefix(password, "keyring:") {
+		return "", fmt.Errorf("password does not reference keyring")
+	}
+	parts := strings.SplitN(password, ":", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid keyring reference: %s", password)
+	}
+	serviceUsername := strings.SplitN(parts[1], "/", 2)
+	if len(serviceUsername) != 2 {
+		return "", fmt.Errorf("invalid keyring format: %s", parts[1])
+	}
+	pw, err := keyring.Get(serviceUsername[0], serviceUsername[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve password from keyring for %s/%s: %w", serviceUsername[0], serviceUsername[1], err)
+	}
+	return pw, nil
+}
+
+func sanitizeEnvName(name string) string {
+	upper := strings.ToUpper(name)
+	var b strings.Builder
+	for _, r := range upper {
+		if r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return b.String()
+}
+
+func envPrefix(name string) string { return "GOEMQUTITI_" + sanitizeEnvName(name) + "_" }
+
+// ApplyEnvVars loads profile fields from environment variables when FromEnv is set.
+func ApplyEnvVars(p *Profile) {
+	if !p.FromEnv {
+		return
+	}
+	prefix := envPrefix(p.Name)
+	rv := reflect.ValueOf(p).Elem()
+	rt := rv.Type()
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.Name == "FromEnv" {
+			continue
+		}
+		tag := f.Tag.Get("toml")
+		if tag == "" {
+			continue
+		}
+		envName := prefix + strings.ToUpper(strings.ReplaceAll(tag, "-", "_"))
+		val, ok := os.LookupEnv(envName)
+		if !ok {
+			continue
+		}
+		field := rv.Field(i)
+		switch field.Kind() {
+		case reflect.String:
+			field.SetString(val)
+		case reflect.Int:
+			if iv, err := strconv.Atoi(val); err == nil {
+				field.SetInt(int64(iv))
+			}
+		case reflect.Bool:
+			if bv, err := strconv.ParseBool(val); err == nil {
+				field.SetBool(bv)
+			}
+		}
+	}
+}
+
+// LoadConfig reads profiles from a TOML file and resolves keyring references.
+func LoadConfig(filePath string) (*Config, error) {
+	var err error
+	if filePath == "" {
+		if filePath, err = DefaultUserConfigFile(); err != nil {
+			return nil, err
+		}
+	}
+	var cfg Config
+	if _, err := toml.DecodeFile(filePath, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode config file: %w", err)
+	}
+	for i := range cfg.Profiles {
+		p := &cfg.Profiles[i]
+		if p.FromEnv {
+			ApplyEnvVars(p)
+			continue
+		}
+		if strings.HasPrefix(p.Password, "keyring:") {
+			pw, err := RetrievePasswordFromKeyring(p.Password)
+			if err != nil {
+				return nil, err
+			}
+			p.Password = pw
+		}
+	}
+	return &cfg, nil
+}
+
+// LoadProfile returns the named profile from the config file, falling back to the default or first profile.
+func LoadProfile(name, file string) (*Profile, error) {
+	cfg, err := LoadConfig(file)
+	if err != nil {
+		return nil, err
+	}
+	var p *Profile
+	if name != "" {
+		for i := range cfg.Profiles {
+			if cfg.Profiles[i].Name == name {
+				p = &cfg.Profiles[i]
+				break
+			}
+		}
+	} else if cfg.DefaultProfile != "" {
+		for i := range cfg.Profiles {
+			if cfg.Profiles[i].Name == cfg.DefaultProfile {
+				p = &cfg.Profiles[i]
+				break
+			}
+		}
+	}
+	if p == nil && len(cfg.Profiles) > 0 {
+		p = &cfg.Profiles[0]
+	}
+	if p == nil {
+		return nil, fmt.Errorf("no connection profile available")
+	}
+	return p, nil
+}

--- a/connectionform.go
+++ b/connectionform.go
@@ -2,12 +2,27 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/ui"
 )
+
+func envPrefix(name string) string {
+	upper := strings.ToUpper(name)
+	var b strings.Builder
+	for _, r := range upper {
+		if r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('_')
+		}
+	}
+	return "GOEMQUTITI_" + b.String() + "_"
+}
 
 type formField interface {
 	Focus()
@@ -197,7 +212,7 @@ const (
 
 func newConnectionForm(p Profile, idx int) connectionForm {
 	if p.FromEnv {
-		applyEnvVars(&p)
+		config.ApplyEnvVars(&p)
 	}
 	pwKey := ""
 	if p.Name != "" && p.Username != "" {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/importer"
+	"github.com/marang/goemqutiti/tracer"
 )
 
 // type Profile struct {
@@ -50,6 +52,10 @@ import (
 var (
 	importFile  string
 	profileName string
+	traceKey    string
+	traceTopics string
+	traceStart  string
+	traceEnd    string
 )
 
 func init() {
@@ -57,6 +63,10 @@ func init() {
 	flag.StringVar(&importFile, "i", "", "(shorthand)")
 	flag.StringVar(&profileName, "profile", "", "Connection profile to use")
 	flag.StringVar(&profileName, "p", "", "(shorthand)")
+	flag.StringVar(&traceKey, "trace", "", "Trace key to store messages under")
+	flag.StringVar(&traceTopics, "topics", "", "Comma-separated topics to trace")
+	flag.StringVar(&traceStart, "start", "", "Optional RFC3339 trace start time")
+	flag.StringVar(&traceEnd, "end", "", "Optional RFC3339 trace end time")
 }
 
 func main() {
@@ -70,6 +80,13 @@ func main() {
 	defer logFile.Close()
 	// Set log output to file
 	log.SetOutput(logFile)
+
+	if traceKey != "" {
+		if err := tracer.Run(traceKey, traceTopics, profileName, traceStart, traceEnd); err != nil {
+			fmt.Println(err)
+		}
+		return
+	}
 
 	if importFile != "" {
 		runImport(importFile, profileName)
@@ -122,7 +139,7 @@ func runImport(path, profile string) {
 		return
 	}
 	if p.FromEnv {
-		applyEnvVars(p)
+		config.ApplyEnvVars(p)
 	} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 		p.Password = env
 	}

--- a/state.go
+++ b/state.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/marang/goemqutiti/config"
 )
 
 // persistedTopic mirrors topicItem for persistence in the config file.
@@ -33,7 +34,7 @@ type userConfig struct {
 
 // loadState retrieves saved topics and payloads from config.toml.
 func loadState() map[string]connectionData {
-	fp, err := DefaultUserConfigFile()
+	fp, err := config.DefaultUserConfigFile()
 	if err != nil {
 		return map[string]connectionData{}
 	}
@@ -58,7 +59,7 @@ func loadState() map[string]connectionData {
 
 // writeConfig writes the entire configuration back to disk.
 func writeConfig(cfg userConfig) {
-	fp, err := DefaultUserConfigFile()
+	fp, err := config.DefaultUserConfigFile()
 	if err != nil {
 		return
 	}
@@ -72,7 +73,7 @@ func writeConfig(cfg userConfig) {
 
 // saveState updates only the Saved section in config.toml.
 func saveState(data map[string]connectionData) {
-	fp, err := DefaultUserConfigFile()
+	fp, err := config.DefaultUserConfigFile()
 	if err != nil {
 		return
 	}

--- a/tracer/headless.go
+++ b/tracer/headless.go
@@ -1,0 +1,138 @@
+package tracer
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/marang/goemqutiti/config"
+)
+
+type Profile = config.Profile
+
+// mqttClient wraps the MQTT connection for the tracer.
+type mqttClient struct{ client mqtt.Client }
+
+func newMQTTClient(p Profile) (*mqttClient, error) {
+	opts := mqtt.NewClientOptions()
+	brokerURL := fmt.Sprintf("%s://%s:%d", p.Schema, p.Host, p.Port)
+	opts.AddBroker(brokerURL)
+	cid := p.ClientID
+	if p.RandomIDSuffix {
+		cid = fmt.Sprintf("%s-%d", cid, time.Now().UnixNano())
+	}
+	opts.SetClientID(cid)
+	opts.SetUsername(p.Username)
+	if p.Password != "" {
+		opts.SetPassword(p.Password)
+	}
+	if p.MQTTVersion != "" {
+		var ver uint
+		fmt.Sscan(p.MQTTVersion, &ver)
+		if ver != 0 {
+			opts.SetProtocolVersion(ver)
+		}
+	}
+	if p.ConnectTimeout > 0 {
+		opts.SetConnectTimeout(time.Duration(p.ConnectTimeout) * time.Second)
+	}
+	if p.KeepAlive > 0 {
+		opts.SetKeepAlive(time.Duration(p.KeepAlive) * time.Second)
+	}
+	opts.SetAutoReconnect(p.AutoReconnect)
+	if p.CleanStart {
+		opts.SetCleanSession(true)
+	} else {
+		opts.SetCleanSession(false)
+	}
+	if p.LastWillEnabled && p.LastWillTopic != "" {
+		opts.SetWill(p.LastWillTopic, p.LastWillPayload, byte(p.LastWillQos), p.LastWillRetain)
+	}
+	if p.SSL {
+		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+	}
+	client := mqtt.NewClient(opts)
+	if token := client.Connect(); token.Wait() && token.Error() != nil {
+		return nil, fmt.Errorf("failed to connect: %w", token.Error())
+	}
+	return &mqttClient{client: client}, nil
+}
+
+func (m *mqttClient) Subscribe(topic string, qos byte, cb mqtt.MessageHandler) error {
+	token := m.client.Subscribe(topic, qos, cb)
+	token.Wait()
+	return token.Error()
+}
+func (m *mqttClient) Unsubscribe(topic string) error {
+	token := m.client.Unsubscribe(topic)
+	token.Wait()
+	return token.Error()
+}
+func (m *mqttClient) Disconnect() {
+	if m.client != nil && m.client.IsConnected() {
+		m.client.Disconnect(250)
+	}
+}
+
+// Run executes the tracer headlessly using configuration from config.toml.
+func Run(key, topics, profileName, startStr, endStr string) error {
+	if key == "" || topics == "" {
+		return fmt.Errorf("-trace and -topics are required")
+	}
+	var start, end time.Time
+	var err error
+	if startStr != "" {
+		start, err = time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			return fmt.Errorf("invalid start time: %w", err)
+		}
+	}
+	if endStr != "" {
+		end, err = time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			return fmt.Errorf("invalid end time: %w", err)
+		}
+	}
+	p, err := config.LoadProfile(profileName, "")
+	if err != nil {
+		return err
+	}
+	if env := os.Getenv("MQTT_PASSWORD"); env != "" && !p.FromEnv {
+		p.Password = env
+	}
+	client, err := newMQTTClient(*p)
+	if err != nil {
+		return fmt.Errorf("connect error: %w", err)
+	}
+	defer client.Disconnect()
+
+	tlist := strings.Split(topics, ",")
+	for i := range tlist {
+		tlist[i] = strings.TrimSpace(tlist[i])
+	}
+	cfg := Config{Profile: p.Name, Topics: tlist, Start: start, End: end, Key: key}
+	tr := New(cfg, client)
+	if err := tr.Start(); err != nil {
+		return fmt.Errorf("trace start: %w", err)
+	}
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	for tr.Planned() || tr.Running() {
+		select {
+		case <-sig:
+			tr.Stop()
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+
+	for t, c := range tr.Counts() {
+		fmt.Printf("%s: %d\n", t, c)
+	}
+	return nil
+}

--- a/tracer/tracer.go
+++ b/tracer/tracer.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"goemqutiti/history"
+	"github.com/marang/goemqutiti/history"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )

--- a/tracer/tracer_test.go
+++ b/tracer/tracer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"goemqutiti/history"
+	"github.com/marang/goemqutiti/history"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )

--- a/update.go
+++ b/update.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/goemqutiti/config"
 	"github.com/marang/goemqutiti/history"
 )
 
@@ -219,7 +221,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 					}
 					flushStatus(m.connections.statusChan)
 					if p.FromEnv {
-						applyEnvVars(&p)
+						config.ApplyEnvVars(&p)
 					} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 						p.Password = env
 					}
@@ -257,7 +259,7 @@ func (m model) updateConnections(msg tea.Msg) (model, tea.Cmd) {
 				}
 				flushStatus(m.connections.statusChan)
 				if p.FromEnv {
-					applyEnvVars(&p)
+					config.ApplyEnvVars(&p)
 				} else if env := os.Getenv("MQTT_PASSWORD"); env != "" {
 					p.Password = env
 				}


### PR DESCRIPTION
## Summary
- extract connection profile helpers into new `config` package
- update code to use `config.ApplyEnvVars` and `config.LoadProfile`
- show multi-topic example for headless tracing
- add local env prefix helper in connection form

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6887756ac098832494135cc1674ba2bc