### PR TITLE
Improve help text wrapping

### DIFF
--- a/help.go
+++ b/help.go
@@ -11,4 +11,9 @@ Ctrl+D           Exit the program
 Ctrl+Shift+Up    Resize panels (up)
 Ctrl+Shift+Down  Resize panels (down)
 
-Tab/Shift+Tab cycle focus. Enter subscribes to the typed topic. 'x' disconnects in the broker manager. Esc navigates back. Use arrows to move through lists. Press '/' in history to filter.`
+Tab/Shift+Tab cycle focus
+Enter subscribes to the typed topic
+'x' disconnects in the broker manager
+Esc navigates back
+Use arrows to move through lists
+Press '/' in history to filter`


### PR DESCRIPTION
## Summary
- format help text with shorter lines so it doesn't get truncated in the help
  view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688a3f44fe18832490185a9bbfc56326