### PR TITLE
Improve topics manager UI

### DIFF
--- a/config_state_test.go
+++ b/config_state_test.go
@@ -78,7 +78,7 @@ func TestSaveLoadState(t *testing.T) {
 
 	data := map[string]connectionData{
 		"p1": {
-			Topics:   []topicItem{{title: "foo", active: true}},
+			Topics:   []topicItem{{title: "foo", subscribed: true}},
 			Payloads: []payloadItem{{topic: "foo", payload: "bar"}},
 		},
 	}

--- a/connections.go
+++ b/connections.go
@@ -172,7 +172,7 @@ func (m *Connections) saveConfigToFile() {
 	for k, v := range saved {
 		var topics []persistedTopic
 		for _, t := range v.Topics {
-			topics = append(topics, persistedTopic{Title: t.title, Active: t.active})
+			topics = append(topics, persistedTopic{Title: t.title, Active: t.subscribed})
 		}
 		var payloads []persistedPayload
 		for _, p := range v.Payloads {

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -47,7 +47,7 @@ func (m *model) subscribeActiveTopics() {
 		return
 	}
 	for _, t := range m.topics.items {
-		if t.active {
+		if t.subscribed {
 			m.mqttClient.Subscribe(t.title, 0, nil)
 		}
 	}

--- a/model_init.go
+++ b/model_init.go
@@ -129,9 +129,14 @@ func initialModel(conns *Connections) *model {
 			selectionAnchor: -1,
 		},
 		topics: topicsState{
-			input:      ti,
-			items:      []topicItem{},
-			list:       topicsList,
+			input: ti,
+			items: []topicItem{},
+			list:  topicsList,
+			panes: topicsPanes{
+				subscribed:   paneState{sel: 0, page: 0, index: 0},
+				unsubscribed: paneState{sel: 0, page: 0, index: 1},
+				active:       0,
+			},
 			selected:   -1,
 			chipBounds: []chipBound{},
 			vp:         viewport.New(0, 0),
@@ -167,16 +172,19 @@ func initialModel(conns *Connections) *model {
 		},
 	}
 	m.focusables = map[string]Focusable{
-		idTopics:      &nullFocusable{},
-		idTopic:       adapt(&m.topics.input),
-		idMessage:     adapt(&m.message.input),
-		idHistory:     &nullFocusable{},
-		idConnList:    &nullFocusable{},
-		idTopicList:   &nullFocusable{},
-		idPayloadList: &nullFocusable{},
-		idTraceList:   &nullFocusable{},
-		idHelp:        adapt(&m.help),
+		idTopics:         &nullFocusable{},
+		idTopic:          adapt(&m.topics.input),
+		idMessage:        adapt(&m.message.input),
+		idHistory:        &nullFocusable{},
+		idConnList:       &nullFocusable{},
+		idTopicsEnabled:  &m.topics.panes.subscribed,
+		idTopicsDisabled: &m.topics.panes.unsubscribed,
+		idPayloadList:    &nullFocusable{},
+		idTraceList:      &nullFocusable{},
+		idHelp:           adapt(&m.help),
 	}
+	m.topics.panes.subscribed.m = m
+	m.topics.panes.unsubscribed.m = m
 	fitems := make([]Focusable, len(order))
 	for i, id := range order {
 		fitems[i] = m.focusables[id]
@@ -234,6 +242,7 @@ func initialModel(conns *Connections) *model {
 			}
 		}
 	}
+	m.rebuildActiveTopicList()
 	return m
 }
 

--- a/state.go
+++ b/state.go
@@ -55,7 +55,7 @@ func loadState() map[string]connectionData {
 	for k, v := range cfg.Saved {
 		var topics []topicItem
 		for _, t := range v.Topics {
-			topics = append(topics, topicItem{title: t.Title, active: t.Active})
+			topics = append(topics, topicItem{title: t.Title, subscribed: t.Active})
 		}
 		var payloads []payloadItem
 		for _, p := range v.Payloads {
@@ -92,7 +92,7 @@ func saveState(data map[string]connectionData) {
 	for k, v := range data {
 		var topics []persistedTopic
 		for _, t := range v.Topics {
-			topics = append(topics, persistedTopic{Title: t.title, Active: t.active})
+			topics = append(topics, persistedTopic{Title: t.title, Active: t.subscribed})
 		}
 		var payloads []persistedPayload
 		for _, p := range v.Payloads {

--- a/topic_delete_test.go
+++ b/topic_delete_test.go
@@ -9,7 +9,7 @@ import (
 // Test that deleting a topic via confirmation removes it from the list
 func TestDeleteTopic(t *testing.T) {
 	m := initialModel(nil)
-	m.topics.items = []topicItem{{title: "a", active: true}, {title: "b", active: false}}
+	m.topics.items = []topicItem{{title: "a", subscribed: true}, {title: "b", subscribed: false}}
 	m.setFocus(idTopics)
 	m.topics.selected = 0
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'d'}})

--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -21,7 +21,7 @@ func chipCoords(m *model, idx int) (int, int) {
 func setupTopics(m *model) {
 	names := []string{"testtopic", "asdfsedf", "asdasd", "sdfdfasssssd", "asdasdasss", "asasasdfffa", "asasdfa", "aasdf", "asdfa", "asdasasdfasdf"}
 	for _, n := range names {
-		m.topics.items = append(m.topics.items, topicItem{title: n, active: true})
+		m.topics.items = append(m.topics.items, topicItem{title: n, subscribed: true})
 	}
 	m.layout.topics.height = len(names)
 }
@@ -34,7 +34,7 @@ func TestMouseToggleFirstTopic(t *testing.T) {
 	x, y := chipCoords(m, 0)
 	name := m.topics.items[0].title
 	for offset := 0; offset < m.topics.chipBounds[0].height; offset++ {
-		before := m.topics.items[0].active
+		before := m.topics.items[0].subscribed
 		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x, Y: y + offset})
 		idx := -1
 		for i, tpc := range m.topics.items {
@@ -43,7 +43,7 @@ func TestMouseToggleFirstTopic(t *testing.T) {
 				break
 			}
 		}
-		if idx >= 0 && m.topics.items[idx].active == before {
+		if idx >= 0 && m.topics.items[idx].subscribed == before {
 			t.Fatalf("click offset %d did not toggle topic", offset)
 		}
 	}
@@ -58,7 +58,7 @@ func TestMouseToggleThirdRowTopic(t *testing.T) {
 	x, y := chipCoords(m, 6)
 	name := m.topics.items[6].title
 	for offset := 0; offset < m.topics.chipBounds[6].height; offset++ {
-		before := m.topics.items[6].active
+		before := m.topics.items[6].subscribed
 		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x, Y: y + offset})
 		idx := -1
 		for i, tpc := range m.topics.items {
@@ -67,7 +67,7 @@ func TestMouseToggleThirdRowTopic(t *testing.T) {
 				break
 			}
 		}
-		if idx >= 0 && m.topics.items[idx].active == before {
+		if idx >= 0 && m.topics.items[idx].subscribed == before {
 			t.Fatalf("offset %d did not toggle topic 6", offset)
 		}
 	}
@@ -82,7 +82,7 @@ func TestMouseToggleFourthRowTopic(t *testing.T) {
 	x, y := chipCoords(m, 8)
 	name := m.topics.items[8].title
 	for offset := 0; offset < m.topics.chipBounds[8].height; offset++ {
-		before := m.topics.items[8].active
+		before := m.topics.items[8].subscribed
 		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x, Y: y + offset})
 		idx := -1
 		for i, tpc := range m.topics.items {
@@ -91,7 +91,7 @@ func TestMouseToggleFourthRowTopic(t *testing.T) {
 				break
 			}
 		}
-		if idx >= 0 && m.topics.items[idx].active == before {
+		if idx >= 0 && m.topics.items[idx].subscribed == before {
 			t.Fatalf("offset %d did not toggle topic 8", offset)
 		}
 	}
@@ -100,7 +100,7 @@ func TestMouseToggleFourthRowTopic(t *testing.T) {
 func setupManyTopics(m *model, n int) {
 	for i := 0; i < n; i++ {
 		title := fmt.Sprintf("topic-%d", i)
-		m.topics.items = append(m.topics.items, topicItem{title: title, active: true})
+		m.topics.items = append(m.topics.items, topicItem{title: title, subscribed: true})
 	}
 	m.layout.topics.height = n
 }
@@ -115,7 +115,7 @@ func TestMouseToggleFifteenthRowTopic(t *testing.T) {
 		idx := 14 * 3
 		x, y := chipCoords(m, idx)
 		name := m.topics.items[idx].title
-		before := m.topics.items[idx].active
+		before := m.topics.items[idx].subscribed
 
 		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x, Y: y + offset})
 
@@ -127,7 +127,7 @@ func TestMouseToggleFifteenthRowTopic(t *testing.T) {
 				break
 			}
 		}
-		if idx < 0 || m.topics.items[idx].active == before {
+		if idx < 0 || m.topics.items[idx].subscribed == before {
 			t.Fatalf("offset %d did not toggle topic", offset)
 		}
 	}
@@ -150,7 +150,7 @@ func TestMouseToggleWithScroll(t *testing.T) {
 		idx := 6 * 3
 		x, y := chipCoords(m, idx)
 		name := m.topics.items[idx].title
-		before := m.topics.items[idx].active
+		before := m.topics.items[idx].subscribed
 
 		m.Update(tea.MouseMsg{Type: tea.MouseLeft, X: x, Y: y + offset})
 
@@ -161,7 +161,7 @@ func TestMouseToggleWithScroll(t *testing.T) {
 				break
 			}
 		}
-		if idx < 0 || m.topics.items[idx].active == before {
+		if idx < 0 || m.topics.items[idx].subscribed == before {
 			t.Fatalf("offset %d did not toggle topic", offset)
 		}
 	}

--- a/topic_publish_test.go
+++ b/topic_publish_test.go
@@ -15,7 +15,7 @@ func TestEnterAddsTopic(t *testing.T) {
 	if cmd == nil {
 		t.Fatalf("expected command on enter")
 	}
-	if len(m.topics.items) != 1 || m.topics.items[0].title != "foo" || !m.topics.items[0].active {
+	if len(m.topics.items) != 1 || m.topics.items[0].title != "foo" || !m.topics.items[0].subscribed {
 		t.Fatalf("topic not added: %#v", m.topics.items)
 	}
 }
@@ -23,7 +23,7 @@ func TestEnterAddsTopic(t *testing.T) {
 // Test that ctrl+s publishes the message in the editor
 func TestCtrlSPublishesMessage(t *testing.T) {
 	m := initialModel(nil)
-	m.topics.items = []topicItem{{title: "foo", active: true}}
+	m.topics.items = []topicItem{{title: "foo", subscribed: true}}
 	m.message.input.SetValue("hello")
 	m.setFocus(idMessage)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlS})

--- a/update_tracer.go
+++ b/update_tracer.go
@@ -40,7 +40,7 @@ func (m model) updateTraces(msg tea.Msg) (model, tea.Cmd) {
 			}
 			topics := []string{}
 			for _, t := range m.topics.items {
-				if t.active {
+				if t.subscribed {
 					topics = append(topics, t.title)
 				}
 			}


### PR DESCRIPTION
## Summary
- replace single pane ID with focusable Enabled and Disabled pane IDs
- implement `paneState` using the `Focusable` interface to swap panes
- update topics state initialization and focusables mapping
- handle pane switching with `setActivePane` and arrow keys
- highlight the active pane in the topics view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688aa6ddf74c8324aa2b950530cef996