### PR TITLE
ci: add deb rpm and flatpak workflows

### DIFF
--- a/.github/workflows/deb.yml
+++ b/.github/workflows/deb.yml
@@ -1,0 +1,49 @@
+name: Publish DEB
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deb:
+    runs-on: ubuntu-latest
+    container: ubuntu:latest
+
+    env:
+      PKGNAME: emqutiti
+      VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Install deps
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            curl git golang-go build-essential
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Strip leading v from tag
+        id: v
+        run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary
+        run: go build -ldflags "-s -w" -o build/emqutiti
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build DEB package
+        run: |
+          ver="${{ steps.v.outputs.version }}"
+          nfpm pkg --config nfpm.yaml --packager deb \
+            --target emqutiti_${ver}_amd64.deb --version ${ver}
+
+      - name: Publish DEB
+        uses: cloudsmith-io/github-action@v1
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          owner: ${{ secrets.CLOUDSMITH_OWNER }}
+          repo: ${{ secrets.CLOUDSMITH_REPO_DEB }}
+          file: emqutiti_${{ steps.v.outputs.version }}_amd64.deb

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,0 +1,46 @@
+name: Publish Flatpak
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  flatpak:
+    runs-on: ubuntu-latest
+
+    env:
+      VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            flatpak flatpak-builder golang-go
+          flatpak remote-add --if-not-exists flathub \
+            https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Strip leading v from tag
+        id: v
+        run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Flatpak
+        run: flatpak-builder --force-clean build-dir flatpak/io.marang.GoEmqutiti.yml
+
+      - name: Create bundle
+        run: |
+          ver="${{ steps.v.outputs.version }}"
+          flatpak build-bundle build-dir emqutiti-${ver}.flatpak io.marang.GoEmqutiti
+
+      - name: Publish Flatpak
+        run: |
+          curl -H "Authorization: Bearer $FLATPAK_TOKEN" \
+            -F "file=@emqutiti-${{ steps.v.outputs.version }}.flatpak" \
+            $FLATPAK_REPO_URL
+        env:
+          FLATPAK_TOKEN: ${{ secrets.FLATPAK_TOKEN }}
+          FLATPAK_REPO_URL: ${{ secrets.FLATPAK_REPO_URL }}

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -1,0 +1,47 @@
+name: Publish RPM
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  rpm:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+
+    env:
+      PKGNAME: emqutiti
+      VERSION: ${{ github.ref_name }}
+
+    steps:
+      - name: Install deps
+        run: |
+          dnf -y install git golang make rpm-build curl
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Strip leading v from tag
+        id: v
+        run: echo "version=${VERSION#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build binary
+        run: go build -ldflags "-s -w" -o build/emqutiti
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+
+      - name: Build RPM package
+        run: |
+          ver="${{ steps.v.outputs.version }}"
+          nfpm pkg --config nfpm.yaml --packager rpm \
+            --target emqutiti-${ver}-1.x86_64.rpm --version ${ver}
+
+      - name: Publish RPM
+        uses: cloudsmith-io/github-action@v1
+        with:
+          api-key: ${{ secrets.CLOUDSMITH_API_KEY }}
+          owner: ${{ secrets.CLOUDSMITH_OWNER }}
+          repo: ${{ secrets.CLOUDSMITH_REPO_RPM }}
+          file: emqutiti-${{ steps.v.outputs.version }}-1.x86_64.rpm

--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ go install github.com/marang/goemqutiti@latest
 yay -S emqutiti
 ```
 
+### Debian / Ubuntu
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/marang/emqutiti/setup.deb.sh' | sudo -E bash
+sudo apt install emqutiti
+```
+
+### Fedora
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/marang/emqutiti/setup.rpm.sh' | sudo -E bash
+sudo dnf install emqutiti
+```
+
+### Flatpak
+```bash
+flatpak install flathub io.marang.GoEmqutiti
+```
+
 ## Usage
 
 ```bash

--- a/TODO.md
+++ b/TODO.md
@@ -21,8 +21,9 @@ This file tracks planned improvements for GoEmqutiti.
 
 ## Packaging
 - [x] Provide a `PKGBUILD` for Arch Linux
-- [ ] Debian/Ubuntu package
-- [ ] Fedora RPM
+- [x] Debian/Ubuntu package
+- [x] Fedora RPM
+- [x] Flatpak package
 - [ ] Homebrew formula for macOS users
 
 ## Documentation

--- a/flatpak/io.marang.GoEmqutiti.yml
+++ b/flatpak/io.marang.GoEmqutiti.yml
@@ -1,0 +1,19 @@
+id: io.marang.GoEmqutiti
+runtime: org.freedesktop.Platform
+runtime-version: '23.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.golang
+command: emqutiti
+finish-args:
+  - --share=network
+modules:
+  - name: goemqutiti
+    buildsystem: simple
+    build-options:
+      append-path: /usr/lib/sdk/golang/bin
+    build-commands:
+      - go build -o /app/bin/emqutiti
+    sources:
+      - type: dir
+        path: ../

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,16 @@
+name: emqutiti
+arch: amd64
+platform: linux
+version: 0.0.0
+section: default
+priority: extra
+maintainer: Emqutiti Maintainers <maintainers@example.com>
+description: |
+  GoEmqutiti is a polished MQTT client for the terminal.
+license: MIT
+homepage: https://github.com/marang/goemqutiti
+contents:
+  - src: build/emqutiti
+    dst: /usr/bin/emqutiti
+    file_info:
+      mode: 0755


### PR DESCRIPTION
## Summary
- package releases for Debian/Ubuntu via apt
- package releases for Fedora via rpm
- publish Flatpak bundle
- document Linux install methods

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688cbb2de3c083249220fd5b431dafb6