### PR TITLE
Add tests for connection profile loading and forms

### DIFF
--- a/connection_profile_test.go
+++ b/connection_profile_test.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/zalando/go-keyring"
+
+	"github.com/marang/goemqutiti/internal/files"
 )
 
 // TestApplyEnvVars sets env vars for all Profile fields and ensures they are applied.
@@ -72,5 +78,147 @@ func TestApplyEnvVars(t *testing.T) {
 				t.Errorf("field %s not set", f.Name)
 			}
 		}
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	keyring.MockInit()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	data := `[[profiles]]
+name = "p1"
+username = "u1"
+password = "keyring:svc/u1"
+
+[[profiles]]
+name = "env"
+from_env = true
+`
+	if err := os.WriteFile(cfgPath, []byte(data), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := keyring.Set("svc", "u1", "secret"); err != nil {
+		t.Fatalf("keyring set: %v", err)
+	}
+	os.Setenv("GOEMQUTITI_ENV_HOST", "example.com")
+	os.Setenv("GOEMQUTITI_ENV_PORT", "1884")
+	t.Cleanup(func() {
+		os.Unsetenv("GOEMQUTITI_ENV_HOST")
+		os.Unsetenv("GOEMQUTITI_ENV_PORT")
+	})
+
+	cfg, err := LoadConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("LoadConfig error: %v", err)
+	}
+	if len(cfg.Profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(cfg.Profiles))
+	}
+	if cfg.Profiles[0].Password != "secret" {
+		t.Errorf("keyring password not resolved: %v", cfg.Profiles[0].Password)
+	}
+	p := cfg.Profiles[1]
+	if p.Host != "example.com" || p.Port != 1884 {
+		t.Errorf("env vars not applied: %+v", p)
+	}
+}
+
+func TestLoadConfigKeyringError(t *testing.T) {
+	keyring.MockInit()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.toml")
+	data := `[[profiles]]
+name = "p1"
+username = "u1"
+password = "keyring:svc/u1"
+`
+	if err := os.WriteFile(cfgPath, []byte(data), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfig(cfgPath); err == nil {
+		t.Fatal("expected error for missing keyring entry")
+	}
+}
+
+func TestSavePasswordToKeyring(t *testing.T) {
+	keyring.MockInit()
+	savePasswordToKeyring("svc", "user", "pw")
+	got, err := keyring.Get("emqutiti-svc", "user")
+	if err != nil || got != "pw" {
+		t.Fatalf("got %q err %v", got, err)
+	}
+}
+
+func TestSaveConfig(t *testing.T) {
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", oldHome)
+
+	profiles := []Profile{{Name: "a"}}
+	saveConfig(profiles, "a")
+	cfgPath, _ := DefaultUserConfigFile()
+	var cfg userConfig
+	if _, err := toml.DecodeFile(cfgPath, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if cfg.DefaultProfileName != "a" || len(cfg.Profiles) != 1 || cfg.Profiles[0].Name != "a" {
+		t.Fatalf("unexpected cfg: %#v", cfg)
+	}
+}
+
+func TestDeleteProfileData(t *testing.T) {
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", oldHome)
+
+	base := files.DataDir("p1")
+	os.MkdirAll(filepath.Join(base, "history"), 0755)
+	os.MkdirAll(filepath.Join(base, "traces"), 0755)
+
+	deleteProfileData("p1")
+
+	if _, err := os.Stat(filepath.Join(base, "history")); !os.IsNotExist(err) {
+		t.Fatalf("history not deleted")
+	}
+	if _, err := os.Stat(filepath.Join(base, "traces")); !os.IsNotExist(err) {
+		t.Fatalf("traces not deleted")
+	}
+}
+
+func TestPersistProfileChange(t *testing.T) {
+	keyring.MockInit()
+	dir := t.TempDir()
+	oldHome := os.Getenv("HOME")
+	os.Setenv("HOME", dir)
+	defer os.Setenv("HOME", oldHome)
+
+	profiles := []Profile{}
+	p := Profile{Name: "test", Username: "user", Password: "secret"}
+	persistProfileChange(&profiles, "test", p, -1)
+
+	if len(profiles) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(profiles))
+	}
+	if profiles[0].Password != "keyring:emqutiti-test/user" {
+		t.Fatalf("password not rewritten: %v", profiles[0].Password)
+	}
+
+	cfgPath, _ := DefaultUserConfigFile()
+	var cfg userConfig
+	if _, err := toml.DecodeFile(cfgPath, &cfg); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(cfg.Profiles) != 1 || cfg.Profiles[0].Password != "keyring:emqutiti-test/user" {
+		t.Fatalf("config not written: %#v", cfg)
+	}
+	if cfg.DefaultProfileName != "test" {
+		t.Fatalf("default not saved: %#v", cfg)
+	}
+	pw, err := keyring.Get("emqutiti-test", "user")
+	if err != nil || pw != "secret" {
+		t.Fatalf("keyring not saved: %q %v", pw, err)
 	}
 }

--- a/connectionform_test.go
+++ b/connectionform_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewConnectionFormEnvReadOnly(t *testing.T) {
+	os.Setenv("GOEMQUTITI_ENV_HOST", "envhost")
+	os.Setenv("GOEMQUTITI_ENV_PORT", "1884")
+	t.Cleanup(func() {
+		os.Unsetenv("GOEMQUTITI_ENV_HOST")
+		os.Unsetenv("GOEMQUTITI_ENV_PORT")
+	})
+	cf := newConnectionForm(Profile{Name: "env", FromEnv: true}, 0)
+	hostField, ok := cf.fields[fieldIndex["Host"]].(*textField)
+	if !ok || hostField.Value() != "envhost" {
+		t.Fatalf("host not loaded from env: %v", hostField)
+	}
+	portField := cf.fields[fieldIndex["Port"]].(*textField)
+	if portField.Value() != "1884" {
+		t.Fatalf("port not loaded from env: %s", portField.Value())
+	}
+	idxName := fieldIndex["Name"]
+	idxFromEnv := fieldIndex["FromEnv"]
+	for i, fld := range cf.fields {
+		if i == idxName || i == idxFromEnv {
+			continue
+		}
+		switch f := fld.(type) {
+		case *textField:
+			if !f.readOnly {
+				t.Errorf("field %s not read-only", formFields[i].key)
+			}
+		case *selectField:
+			if !f.readOnly {
+				t.Errorf("field %s not read-only", formFields[i].key)
+			}
+		case *checkField:
+			if !f.readOnly {
+				t.Errorf("field %s not read-only", formFields[i].key)
+			}
+		}
+	}
+}
+
+func TestNewConnectionFormPasswordPlaceholder(t *testing.T) {
+	cf := newConnectionForm(Profile{Name: "test", Username: "user", Password: "secret"}, 0)
+	tf, ok := cf.fields[fieldIndex["Password"]].(*textField)
+	if !ok {
+		t.Fatalf("password field not text")
+	}
+	if tf.Model.Placeholder != "keyring:emqutiti-test/user" {
+		t.Fatalf("unexpected placeholder %s", tf.Model.Placeholder)
+	}
+}
+
+func TestConnectionFormProfile(t *testing.T) {
+	cf := newConnectionForm(Profile{}, -1)
+	cf.fields[fieldIndex["Name"]].(*textField).SetValue("n1")
+	cf.fields[fieldIndex["Port"]].(*textField).SetValue("1883")
+	cf.fields[fieldIndex["AutoReconnect"]].(*checkField).value = true
+	cf.fields[fieldIndex["QoS"]].(*selectField).index = 2
+
+	p := cf.Profile()
+	if p.Name != "n1" || p.Port != 1883 || !p.AutoReconnect || p.QoS != 2 {
+		t.Fatalf("unexpected profile: %#v", p)
+	}
+}
+
+func TestConnectionFormProfileInvalidInt(t *testing.T) {
+	cf := newConnectionForm(Profile{}, -1)
+	cf.fields[fieldIndex["Port"]].(*textField).SetValue("abc")
+	p := cf.Profile()
+	if p.Port != 0 {
+		t.Fatalf("expected port 0, got %d", p.Port)
+	}
+}


### PR DESCRIPTION
## Summary
- cover LoadConfig, environment overrides, and persistence helper logic
- verify connection form generation and Profile conversion with error cases

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688d25d01ea08324a1eb174a17918cdd