### PR TITLE
refactor: move entrypoint under cmd

### DIFF
--- a/client_keys.go
+++ b/client_keys.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/client_keys_history_select.go
+++ b/client_keys_history_select.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/list"

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/cmd/emqutiti/main.go
+++ b/cmd/emqutiti/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/marang/emqutiti"
+
+func main() {
+	emqutiti.Main()
+}

--- a/config_state_test.go
+++ b/config_state_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/connection_profile.go
+++ b/connection_profile.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/connection_profile_config.go
+++ b/connection_profile_config.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/connection_profile_env.go
+++ b/connection_profile_env.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/connection_profile_store.go
+++ b/connection_profile_store.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"errors"

--- a/connection_profile_test.go
+++ b/connection_profile_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/connectionform.go
+++ b/connectionform.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"errors"

--- a/connectionform_test.go
+++ b/connectionform_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/connections.go
+++ b/connections.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"log"

--- a/connections_delegate.go
+++ b/connections_delegate.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/focus.go
+++ b/focus.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 

--- a/focus_test.go
+++ b/focus_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "testing"
 

--- a/focusmap.go
+++ b/focusmap.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 

--- a/help.go
+++ b/help.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	_ "embed"

--- a/help_test.go
+++ b/help_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/history_delegate.go
+++ b/history_delegate.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/history_select_test.go
+++ b/history_select_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/history_util.go
+++ b/history_util.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "github.com/charmbracelet/bubbles/list"
 

--- a/history_util_test.go
+++ b/history_util_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"bytes"

--- a/historyfilter.go
+++ b/historyfilter.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/historystore.go
+++ b/historystore.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"encoding/json"

--- a/historystore_archive_test.go
+++ b/historystore_archive_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/historystore_query_test.go
+++ b/historystore_query_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"reflect"

--- a/historystore_search_test.go
+++ b/historystore_search_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/importer_reader.go
+++ b/importer_reader.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"encoding/csv"

--- a/importer_reader_test.go
+++ b/importer_reader_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"encoding/json"

--- a/importer_wizard.go
+++ b/importer_wizard.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/importer_wizard_done.go
+++ b/importer_wizard_done.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/importer_wizard_file.go
+++ b/importer_wizard_file.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/importer_wizard_map.go
+++ b/importer_wizard_map.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/importer_wizard_publish.go
+++ b/importer_wizard_publish.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/importer_wizard_review.go
+++ b/importer_wizard_review.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/importer_wizard_template.go
+++ b/importer_wizard_template.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/importer_wizard_test.go
+++ b/importer_wizard_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"errors"

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/model.go
+++ b/model.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/viewport"

--- a/model_base.go
+++ b/model_base.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 const (
 	idTopics         = "topics"          // topics chip list

--- a/model_connections.go
+++ b/model_connections.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 type connectionItem struct {
 	title  string

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/list"

--- a/model_history.go
+++ b/model_history.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/model_init.go
+++ b/model_init.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/model_messages.go
+++ b/model_messages.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/list"

--- a/model_topics.go
+++ b/model_topics.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/model_traces.go
+++ b/model_traces.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"crypto/tls"

--- a/run.go
+++ b/run.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"flag"
@@ -32,9 +32,9 @@ func init() {
 	flag.StringVar(&traceEnd, "end", "", "Optional RFC3339 trace end time")
 }
 
-// main parses flags, sets up logging, and launches the UI or other modes.
+// Main parses flags, sets up logging, and launches the UI or other modes.
 
-func main() {
+func Main() {
 	flag.Parse()
 
 	if traceKey != "" {

--- a/state.go
+++ b/state.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"bytes"

--- a/topic_delete_test.go
+++ b/topic_delete_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/topic_mouse_test.go
+++ b/topic_mouse_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/topic_publish_test.go
+++ b/topic_publish_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/topic_scroll_test.go
+++ b/topic_scroll_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/trace_delegate.go
+++ b/trace_delegate.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/traceform.go
+++ b/traceform.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/tracer_counts.go
+++ b/tracer_counts.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 // LoadCounts returns per-topic counts for the given trace key aggregated by
 // the provided subscription topics.

--- a/tracer_headless.go
+++ b/tracer_headless.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"crypto/tls"

--- a/tracer_match.go
+++ b/tracer_match.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "strings"
 

--- a/tracer_match_test.go
+++ b/tracer_match_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "testing"
 

--- a/tracer_message.go
+++ b/tracer_message.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "time"
 

--- a/tracer_runtime.go
+++ b/tracer_runtime.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"context"

--- a/tracer_runtime_test.go
+++ b/tracer_runtime_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/tracer_store.go
+++ b/tracer_store.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"encoding/json"

--- a/tracer_store_test.go
+++ b/tracer_store_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/update.go
+++ b/update.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_client.go
+++ b/update_client.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/update_confirm.go
+++ b/update_confirm.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_connection.go
+++ b/update_connection.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/update_connections.go
+++ b/update_connections.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/update_form.go
+++ b/update_form.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 

--- a/update_help.go
+++ b/update_help.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_history.go
+++ b/update_history.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"time"

--- a/update_history_detail.go
+++ b/update_history_detail.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_history_filter.go
+++ b/update_history_filter.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/list"

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/update_importer.go
+++ b/update_importer.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_payloads.go
+++ b/update_payloads.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"

--- a/update_topics.go
+++ b/update_topics.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/update_tracer.go
+++ b/update_tracer.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"os"

--- a/view.go
+++ b/view.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/view_client.go
+++ b/view_client.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import "github.com/charmbracelet/lipgloss"
 

--- a/view_confirm_delete.go
+++ b/view_confirm_delete.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_connections.go
+++ b/view_connections.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_form.go
+++ b/view_form.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_help.go
+++ b/view_help.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_history_detail.go
+++ b/view_history_detail.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"strings"

--- a/view_history_filter.go
+++ b/view_history_filter.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_importer.go
+++ b/view_importer.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 // viewImporter renders the importer wizard view.
 func (m model) viewImporter() string {

--- a/view_payloads.go
+++ b/view_payloads.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/view_topics.go
+++ b/view_topics.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/bubbles/list"

--- a/view_trace_form.go
+++ b/view_trace_form.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/marang/emqutiti/ui"

--- a/view_trace_messages.go
+++ b/view_trace_messages.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"

--- a/view_traces.go
+++ b/view_traces.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"github.com/charmbracelet/lipgloss"

--- a/viewport_scroll_test.go
+++ b/viewport_scroll_test.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"testing"

--- a/views_client.go
+++ b/views_client.go
@@ -1,4 +1,4 @@
-package main
+package emqutiti
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary
- move program entrypoint to `cmd/emqutiti`
- expose `Main` function and rename top-level package for reuse

## Testing
- `go build ./cmd/emqutiti`
- `go vet ./...`
- `go test ./...` *(hangs, requires TTY)*

------
https://chatgpt.com/codex/tasks/task_e_688e11514ab0832494f1a89992ed03b4