### PR TITLE
refactor: move importer to internal package

### DIFF
--- a/internal/importer/importer_reader.go
+++ b/internal/importer/importer_reader.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"encoding/csv"

--- a/internal/importer/importer_reader_test.go
+++ b/internal/importer/importer_reader_test.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"encoding/json"

--- a/internal/importer/importer_wizard.go
+++ b/internal/importer/importer_wizard.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"fmt"

--- a/internal/importer/importer_wizard_done.go
+++ b/internal/importer/importer_wizard_done.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"fmt"

--- a/internal/importer/importer_wizard_file.go
+++ b/internal/importer/importer_wizard_file.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"strings"

--- a/internal/importer/importer_wizard_map.go
+++ b/internal/importer/importer_wizard_map.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"fmt"

--- a/internal/importer/importer_wizard_publish.go
+++ b/internal/importer/importer_wizard_publish.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"fmt"

--- a/internal/importer/importer_wizard_review.go
+++ b/internal/importer/importer_wizard_review.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"fmt"

--- a/internal/importer/importer_wizard_template.go
+++ b/internal/importer/importer_wizard_template.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"strings"

--- a/internal/importer/importer_wizard_test.go
+++ b/internal/importer/importer_wizard_test.go
@@ -1,4 +1,4 @@
-package main
+package importer
 
 import (
 	"errors"

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/internal/importer"
 )
 
 var (
@@ -108,7 +110,7 @@ func runImport(path, profile string) error {
 	}
 	defer client.Disconnect()
 
-	w := NewImportWizard(client, path)
+	w := importer.NewImportWizard(client, path)
 	prog := tea.NewProgram(w, tea.WithAltScreen())
 	if _, err := prog.Run(); err != nil {
 		return fmt.Errorf("import error: %w", err)

--- a/model.go
+++ b/model.go
@@ -3,6 +3,8 @@ package main
 import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/internal/importer"
 )
 
 type boxConfig struct {
@@ -52,7 +54,7 @@ type model struct {
 	message      messageState
 	traces       tracesState
 	help         helpState
-	importWizard *ImportWizard
+	importWizard *importer.ImportWizard
 
 	ui uiState
 

--- a/model_init.go
+++ b/model_init.go
@@ -13,6 +13,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/marang/emqutiti/internal/importer"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -232,7 +233,7 @@ func initialModel(conns *Connections) (*model, error) {
 			if client, err := NewMQTTClient(cfg, nil); err == nil {
 				m.mqttClient = client
 				m.connections.active = cfg.Name
-				m.importWizard = NewImportWizard(client, importFile)
+				m.importWizard = importer.NewImportWizard(client, importFile)
 				m.setMode(modeImporter)
 			} else {
 				return nil, fmt.Errorf("connect error: %w", err)

--- a/update_importer.go
+++ b/update_importer.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/internal/importer"
 )
 
 // updateImporter forwards messages to the import wizard when active.
@@ -10,7 +12,7 @@ func (m *model) updateImporter(msg tea.Msg) tea.Cmd {
 		return nil
 	}
 	nm, cmd := m.importWizard.Update(msg)
-	if w, ok := nm.(*ImportWizard); ok {
+	if w, ok := nm.(*importer.ImportWizard); ok {
 		m.importWizard = w
 	}
 	return cmd


### PR DESCRIPTION
## Summary
- move importer files to internal/importer package
- update main code to use importer.NewImportWizard
- reference importer.ImportWizard in model and initialization

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e116c9dbc8324a4f1cfe08d2329d1