### PR TITLE
refactor: add component interface for mode delegation

### DIFF
--- a/model.go
+++ b/model.go
@@ -5,6 +5,61 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
+// Component defines a screen or feature that can participate in the Tea update
+// and view cycle. Implementations handle their own initialization, state
+// updates, rendering and focus management.
+type Component interface {
+	Init() tea.Cmd
+	Update(tea.Msg) tea.Cmd
+	View() string
+	Focus() tea.Cmd
+	Blur()
+}
+
+// component is a lightweight adapter that allows plain functions to satisfy
+// the Component interface. Missing functions simply result in no-ops.
+type component struct {
+	init   func() tea.Cmd
+	update func(tea.Msg) tea.Cmd
+	view   func() string
+	focus  func() tea.Cmd
+	blur   func()
+}
+
+func (c component) Init() tea.Cmd {
+	if c.init != nil {
+		return c.init()
+	}
+	return nil
+}
+
+func (c component) Update(msg tea.Msg) tea.Cmd {
+	if c.update != nil {
+		return c.update(msg)
+	}
+	return nil
+}
+
+func (c component) View() string {
+	if c.view != nil {
+		return c.view()
+	}
+	return ""
+}
+
+func (c component) Focus() tea.Cmd {
+	if c.focus != nil {
+		return c.focus()
+	}
+	return nil
+}
+
+func (c component) Blur() {
+	if c.blur != nil {
+		c.blur()
+	}
+}
+
 type boxConfig struct {
 	height int
 }
@@ -63,6 +118,11 @@ type model struct {
 	confirmReturnFocus string
 
 	layout layoutConfig
+
+	// components maps each application mode to its corresponding component
+	// implementation. These components handle mode-specific update and view
+	// logic which the model delegates to at runtime.
+	components map[appMode]Component
 
 	focusables map[string]Focusable
 	focus      *FocusMap

--- a/model_init.go
+++ b/model_init.go
@@ -194,6 +194,31 @@ func initialModel(conns *Connections) (*model, error) {
 	m.history.list.SetDelegate(hDel)
 	traceDel.m = m
 	m.traces.view.SetDelegate(traceDel)
+
+	// Register mode components so that view and update logic can be
+	// delegated based on the current application mode.
+	m.components = map[appMode]Component{
+		modeClient:         component{update: m.updateClient, view: m.viewClient},
+		modeConnections:    component{update: m.updateConnections, view: m.viewConnections},
+		modeEditConnection: component{update: m.updateForm, view: m.viewForm},
+		modeConfirmDelete:  component{update: m.updateConfirmDelete, view: m.viewConfirmDelete},
+		modeTopics:         component{update: m.updateTopics, view: m.viewTopics},
+		modePayloads:       component{update: m.updatePayloads, view: m.viewPayloads},
+		modeTracer:         component{update: m.updateTraces, view: m.viewTraces},
+		modeEditTrace:      component{update: m.updateTraceForm, view: m.viewTraceForm},
+		modeViewTrace:      component{update: m.updateTraceView, view: m.viewTraceMessages},
+		modeImporter:       component{update: m.updateImporter, view: m.viewImporter},
+		modeHistoryFilter:  component{update: m.updateHistoryFilter, view: m.viewHistoryFilter},
+		modeHistoryDetail:  component{update: m.updateHistoryDetail, view: m.viewHistoryDetail},
+		modeHelp: component{
+			update: func(msg tea.Msg) tea.Cmd {
+				nm, cmd := m.updateHelp(msg)
+				*m = nm
+				return cmd
+			},
+			view: m.viewHelp,
+		},
+	}
 	if idx, err := openHistoryStore(""); err == nil {
 		m.history.store = idx
 		msgs := idx.Search(false, nil, time.Time{}, time.Time{}, "")

--- a/update.go
+++ b/update.go
@@ -107,48 +107,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	switch m.currentMode() {
-	case modeClient:
-		cmd := m.updateClient(msg)
+	if c, ok := m.components[m.currentMode()]; ok {
+		cmd := c.Update(msg)
 		return m, cmd
-	case modeConnections:
-		cmd := m.updateConnections(msg)
-		return m, cmd
-	case modeEditConnection:
-		cmd := m.updateForm(msg)
-		return m, cmd
-	case modeConfirmDelete:
-		cmd := m.updateConfirmDelete(msg)
-		return m, cmd
-	case modeTopics:
-		cmd := m.updateTopics(msg)
-		return m, cmd
-	case modePayloads:
-		cmd := m.updatePayloads(msg)
-		return m, cmd
-	case modeTracer:
-		cmd := m.updateTraces(msg)
-		return m, cmd
-	case modeEditTrace:
-		cmd := m.updateTraceForm(msg)
-		return m, cmd
-	case modeViewTrace:
-		cmd := m.updateTraceView(msg)
-		return m, cmd
-	case modeImporter:
-		cmd := m.updateImporter(msg)
-		return m, cmd
-	case modeHistoryFilter:
-		cmd := m.updateHistoryFilter(msg)
-		return m, cmd
-	case modeHistoryDetail:
-		cmd := m.updateHistoryDetail(msg)
-		return m, cmd
-	case modeHelp:
-		nm, cmd := m.updateHelp(msg)
-		*m = nm
-		return m, cmd
-	default:
-		return m, nil
 	}
+	return m, nil
 }

--- a/view.go
+++ b/view.go
@@ -28,34 +28,8 @@ func (m *model) overlayHelp(view string) string {
 
 // View renders the application UI based on the current mode.
 func (m *model) View() string {
-	switch m.currentMode() {
-	case modeClient:
-		return m.viewClient()
-	case modeConnections:
-		return m.viewConnections()
-	case modeEditConnection:
-		return m.viewForm()
-	case modeConfirmDelete:
-		return m.viewConfirmDelete()
-	case modeTopics:
-		return m.viewTopics()
-	case modePayloads:
-		return m.viewPayloads()
-	case modeTracer:
-		return m.viewTraces()
-	case modeEditTrace:
-		return m.viewTraceForm()
-	case modeViewTrace:
-		return m.viewTraceMessages()
-	case modeImporter:
-		return m.viewImporter()
-	case modeHistoryFilter:
-		return m.viewHistoryFilter()
-	case modeHistoryDetail:
-		return m.viewHistoryDetail()
-	case modeHelp:
-		return m.viewHelp()
-	default:
-		return ""
+	if c, ok := m.components[m.currentMode()]; ok {
+		return c.View()
 	}
+	return ""
 }

--- a/view_confirm_delete.go
+++ b/view_confirm_delete.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewConfirmDelete displays a confirmation dialog.
-func (m model) viewConfirmDelete() string {
+func (m *model) viewConfirmDelete() string {
 	m.ui.elemPos = map[string]int{}
 	content := m.confirmPrompt
 	if m.confirmInfo != "" {

--- a/view_connections.go
+++ b/view_connections.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewConnections shows the list of saved broker profiles.
-func (m model) viewConnections() string {
+func (m *model) viewConnections() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idConnList] = 1
 	listView := m.connections.manager.ConnectionsList.View()

--- a/view_form.go
+++ b/view_form.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewForm renders the add/edit broker form alongside the list.
-func (m model) viewForm() string {
+func (m *model) viewForm() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idConnList] = 1
 	if m.connections.form == nil {

--- a/view_help.go
+++ b/view_help.go
@@ -6,7 +6,7 @@ import (
 	"github.com/marang/emqutiti/ui"
 )
 
-func (m model) viewHelp() string {
+func (m *model) viewHelp() string {
 	m.ui.elemPos = map[string]int{}
 	m.help.vp.SetContent(helpText)
 	content := m.help.vp.View()

--- a/view_history_detail.go
+++ b/view_history_detail.go
@@ -9,7 +9,7 @@ import (
 )
 
 // viewHistoryDetail renders the full payload of a history message.
-func (m model) viewHistoryDetail() string {
+func (m *model) viewHistoryDetail() string {
 	m.ui.elemPos = map[string]int{}
 	lines := strings.Split(m.history.detail.View(), "\n")
 	help := ui.InfoStyle.Render("[esc] back")

--- a/view_history_filter.go
+++ b/view_history_filter.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewHistoryFilter displays the history filter form.
-func (m model) viewHistoryFilter() string {
+func (m *model) viewHistoryFilter() string {
 	m.ui.elemPos = map[string]int{}
 	if m.history.filterForm == nil {
 		return ""

--- a/view_importer.go
+++ b/view_importer.go
@@ -1,7 +1,7 @@
 package emqutiti
 
 // viewImporter renders the importer wizard view.
-func (m model) viewImporter() string {
+func (m *model) viewImporter() string {
 	m.ui.elemPos = map[string]int{}
 	if m.importWizard == nil {
 		return ""

--- a/view_payloads.go
+++ b/view_payloads.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewPayloads shows stored payloads for reuse.
-func (m model) viewPayloads() string {
+func (m *model) viewPayloads() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idPayloadList] = 1
 	listView := m.message.list.View()

--- a/view_topics.go
+++ b/view_topics.go
@@ -8,7 +8,7 @@ import (
 )
 
 // viewTopics displays the topic manager list.
-func (m model) viewTopics() string {
+func (m *model) viewTopics() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idTopicsEnabled] = 1
 	m.ui.elemPos[idTopicsDisabled] = 1

--- a/view_trace_form.go
+++ b/view_trace_form.go
@@ -5,7 +5,7 @@ import (
 )
 
 // viewTraceForm renders the form for new traces.
-func (m model) viewTraceForm() string {
+func (m *model) viewTraceForm() string {
 	m.ui.elemPos = map[string]int{}
 	content := m.traces.form.View()
 	view := ui.LegendBox(content, "New Trace", m.ui.width-2, 0, ui.ColBlue, true, -1)

--- a/view_trace_messages.go
+++ b/view_trace_messages.go
@@ -8,7 +8,7 @@ import (
 )
 
 // viewTraceMessages shows captured messages for a trace.
-func (m model) viewTraceMessages() string {
+func (m *model) viewTraceMessages() string {
 	m.ui.elemPos = map[string]int{}
 	title := fmt.Sprintf("Trace %s", m.traces.viewKey)
 	listLines := strings.Split(m.traces.view.View(), "\n")

--- a/view_traces.go
+++ b/view_traces.go
@@ -7,7 +7,7 @@ import (
 )
 
 // viewTraces lists configured traces and their state.
-func (m model) viewTraces() string {
+func (m *model) viewTraces() string {
 	m.ui.elemPos = map[string]int{}
 	m.ui.elemPos[idTraceList] = 1
 	listView := m.traces.list.View()


### PR DESCRIPTION
## Summary
- add Component interface and helper wrapper
- map app modes to components for delegating update and view
- route model Update and View through active component

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e1e98da3c8324b467d4afecf39289