### PR TITLE
refactor: build focus map from component focusables

### DIFF
--- a/confirm_component.go
+++ b/confirm_component.go
@@ -94,3 +94,6 @@ func (c *confirmComponent) Focus() tea.Cmd {
 func (c *confirmComponent) Blur() { c.focused = false }
 
 func (c *confirmComponent) Focused() bool { return c.focused }
+
+// Focusables exposes focusable elements for the confirm component.
+func (c *confirmComponent) Focusables() map[string]Focusable { return map[string]Focusable{} }

--- a/connections_component.go
+++ b/connections_component.go
@@ -253,3 +253,8 @@ func (c *connectionsComponent) Focus() tea.Cmd {
 
 // Blur marks the component as blurred.
 func (c *connectionsComponent) Blur() { c.m.connections.manager.Focused = false }
+
+// Focusables exposes focusable elements for the connections component.
+func (c *connectionsComponent) Focusables() map[string]Focusable {
+	return map[string]Focusable{idConnList: &nullFocusable{}}
+}

--- a/focusmap.go
+++ b/focusmap.go
@@ -10,6 +10,11 @@ type Focusable interface {
 	View() string
 }
 
+// FocusableSet exposes a collection of focusable elements.
+type FocusableSet interface {
+	Focusables() map[string]Focusable
+}
+
 type teaFocusable interface {
 	Focus() tea.Cmd
 	Blur()

--- a/help_component.go
+++ b/help_component.go
@@ -57,3 +57,8 @@ func (h *helpComponent) Focus() tea.Cmd {
 func (h *helpComponent) Blur() { h.focused = false }
 
 func (h *helpComponent) Focused() bool { return h.focused }
+
+// Focusables exposes focusable elements for the help component.
+func (h *helpComponent) Focusables() map[string]Focusable {
+	return map[string]Focusable{idHelp: adapt(h)}
+}

--- a/model.go
+++ b/model.go
@@ -110,3 +110,14 @@ type model struct {
 	focusables map[string]Focusable
 	focus      *FocusMap
 }
+
+// Focusables returns the base focusable elements managed by the model.
+func (m *model) Focusables() map[string]Focusable {
+	return map[string]Focusable{
+		idTopics:    &nullFocusable{},
+		idTopic:     adapt(&m.topics.input),
+		idMessage:   adapt(&m.message.input),
+		idHistory:   &nullFocusable{},
+		idTraceList: &nullFocusable{},
+	}
+}

--- a/model_init.go
+++ b/model_init.go
@@ -206,20 +206,17 @@ func initialModel(conns *Connections) (*model, error) {
 	connComp := newConnectionsComponent(m)
 	topicsComp := newTopicsComponent(m)
 	m.payloads = newPayloadsComponent(m)
-	m.focusables = map[string]Focusable{
-		idTopics:         &nullFocusable{},
-		idTopic:          adapt(&m.topics.input),
-		idMessage:        adapt(&m.message.input),
-		idHistory:        &nullFocusable{},
-		idConnList:       &nullFocusable{},
-		idTopicsEnabled:  &m.topics.panes.subscribed,
-		idTopicsDisabled: &m.topics.panes.unsubscribed,
-		idPayloadList:    &nullFocusable{},
-		idTraceList:      &nullFocusable{},
-		idHelp:           adapt(m.help),
-	}
 	m.topics.panes.subscribed.m = m
 	m.topics.panes.unsubscribed.m = m
+
+	// Collect focusable elements from model and components.
+	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, m.help}
+	m.focusables = map[string]Focusable{}
+	for _, p := range providers {
+		for id, f := range p.Focusables() {
+			m.focusables[id] = f
+		}
+	}
 	fitems := make([]Focusable, len(order))
 	for i, id := range order {
 		fitems[i] = m.focusables[id]

--- a/payloads_component.go
+++ b/payloads_component.go
@@ -76,6 +76,11 @@ func (p *payloadsComponent) Focus() tea.Cmd { return nil }
 
 func (p *payloadsComponent) Blur() {}
 
+// Focusables exposes focusable elements for the payloads component.
+func (p *payloadsComponent) Focusables() map[string]Focusable {
+	return map[string]Focusable{idPayloadList: &nullFocusable{}}
+}
+
 func (p *payloadsComponent) Add(topic, payload string) {
 	pi := payloadItem{topic: topic, payload: payload}
 	p.items = append(p.items, pi)

--- a/topics_component.go
+++ b/topics_component.go
@@ -117,3 +117,11 @@ func (c *topicsComponent) View() string {
 func (c *topicsComponent) Focus() tea.Cmd { return nil }
 
 func (c *topicsComponent) Blur() {}
+
+// Focusables exposes focusable elements for the topics component.
+func (c *topicsComponent) Focusables() map[string]Focusable {
+	return map[string]Focusable{
+		idTopicsEnabled:  &c.m.topics.panes.subscribed,
+		idTopicsDisabled: &c.m.topics.panes.unsubscribed,
+	}
+}


### PR DESCRIPTION
## Summary
- add `FocusableSet` interface for components to expose focusable elements
- assemble focus map from component-provided focusables

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e5309c69083248b6c4fe77c167e46