### PR TITLE
Use messages for topic subscriptions

### DIFF
--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -110,7 +110,7 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 		}
 	}
 	m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-	m.startConfirm("Delete selected messages? [y/n]", "", func() {
+	m.startConfirm("Delete selected messages? [y/n]", "", func() tea.Cmd {
 		for i := len(m.history.items) - 1; i >= 0; i-- {
 			it := m.history.items[i]
 			if it.isMarkedForDeletion != nil && *it.isMarkedForDeletion {
@@ -140,6 +140,7 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 			m.history.list.Select(len(m.history.items) - 1)
 		}
 		m.history.selectionAnchor = -1
+		return nil
 	})
 	m.confirm.cancel = func() {
 		for i := range m.history.items {

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -46,19 +46,14 @@ func (m *model) handleEnterKey() tea.Cmd {
 			if m.currentMode() == modeTopics {
 				m.rebuildActiveTopicList()
 			}
-			if m.mqttClient != nil {
-				m.mqttClient.Subscribe(topic, 0, nil)
-			}
-			m.appendHistory(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
 			m.topics.input.SetValue("")
+			return func() tea.Msg { return topicToggleMsg{topic: topic, subscribed: true} }
 		}
 	case idTopics:
 		if m.topics.selected >= 0 && m.topics.selected < len(m.topics.items) {
-			m.toggleTopic(m.topics.selected)
+			cmd := m.toggleTopic(m.topics.selected)
 			m.ensureTopicVisible()
-			if m.currentMode() == modeTopics {
-				m.rebuildActiveTopicList()
-			}
+			return cmd
 		}
 	case idHistory:
 		return m.handleHistoryViewKey()
@@ -71,11 +66,12 @@ func (m *model) handleDeleteTopicKey() tea.Cmd {
 	idx := m.topics.selected
 	name := m.topics.items[idx].title
 	m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-	m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() {
-		m.removeTopic(idx)
+	m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() tea.Cmd {
+		cmd := m.removeTopic(idx)
 		if m.currentMode() == modeTopics {
 			m.rebuildActiveTopicList()
 		}
+		return cmd
 	})
 	return nil
 }

--- a/confirm_component.go
+++ b/confirm_component.go
@@ -12,7 +12,7 @@ type confirmComponent struct {
 
 	prompt string
 	info   string
-	action func()
+	action func() tea.Cmd
 	cancel func()
 
 	returnFocus string
@@ -25,7 +25,7 @@ func newConfirmComponent(m *model) *confirmComponent {
 
 func (c *confirmComponent) Init() tea.Cmd { return nil }
 
-func (c *confirmComponent) start(prompt, info string, action func()) {
+func (c *confirmComponent) start(prompt, info string, action func() tea.Cmd) {
 	c.prompt = prompt
 	c.info = info
 	c.action = action
@@ -40,8 +40,9 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 		case "ctrl+d":
 			return tea.Quit
 		case "y":
+			var acmd tea.Cmd
 			if c.action != nil {
-				c.action()
+				acmd = c.action()
 				c.action = nil
 			}
 			if c.cancel != nil {
@@ -49,6 +50,9 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 			}
 			cmd := c.m.setMode(c.m.previousMode())
 			cmds := []tea.Cmd{cmd, c.m.connections.ListenStatus()}
+			if acmd != nil {
+				cmds = append(cmds, acmd)
+			}
 			if c.returnFocus != "" {
 				cmds = append(cmds, c.m.setFocus(c.returnFocus))
 				c.returnFocus = ""

--- a/connections_component.go
+++ b/connections_component.go
@@ -211,10 +211,11 @@ func (c *connectionsComponent) Update(msg tea.Msg) tea.Cmd {
 				name := m.connections.manager.Profiles[i].Name
 				info := "This also deletes history and traces"
 				m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), info, func() {
+				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), info, func() tea.Cmd {
 					m.connections.manager.DeleteConnection(i)
 					m.connections.manager.refreshList()
 					m.refreshConnectionItems()
+					return nil
 				})
 				return m.connections.ListenStatus()
 			}

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -35,7 +35,7 @@ func (m *model) historyIndexAt(y int) int {
 }
 
 // startConfirm displays a confirmation dialog and runs the action on accept.
-func (m *model) startConfirm(prompt, info string, action func()) {
+func (m *model) startConfirm(prompt, info string, action func() tea.Cmd) {
 	m.confirm.start(prompt, info, action)
 }
 

--- a/model_traces.go
+++ b/model_traces.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 // forceStartTrace launches the tracer at index without checking existing data.
@@ -49,9 +50,10 @@ func (m *model) startTrace(index int) {
 	exists, err := tracerHasData(item.cfg.Profile, item.key)
 	if err == nil && exists {
 		m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), "existing trace data will be removed", func() {
+		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), "existing trace data will be removed", func() tea.Cmd {
 			tracerClearData(item.cfg.Profile, item.key)
 			m.forceStartTrace(index)
+			return nil
 		})
 		return
 	}

--- a/topics_component.go
+++ b/topics_component.go
@@ -35,7 +35,7 @@ func (c *topicsComponent) Init() tea.Cmd { return nil }
 // Update manages the topics list UI.
 func (c *topicsComponent) Update(msg tea.Msg) tea.Cmd {
 	m := c.m
-	var cmd, fcmd tea.Cmd
+	var cmd, fcmd, tcmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -57,17 +57,17 @@ func (c *topicsComponent) Update(msg tea.Msg) tea.Cmd {
 			if i >= 0 && i < len(m.topics.items) {
 				name := m.topics.items[i].title
 				m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() {
-					m.removeTopic(i)
+				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() tea.Cmd {
+					cmd := m.removeTopic(i)
 					m.rebuildActiveTopicList()
+					return cmd
 				})
 				return m.connections.ListenStatus()
 			}
 		case "enter", " ":
 			i := m.topics.selected
 			if i >= 0 && i < len(m.topics.items) {
-				m.toggleTopic(i)
-				m.rebuildActiveTopicList()
+				tcmd = m.toggleTopic(i)
 			}
 		}
 	}
@@ -80,7 +80,7 @@ func (c *topicsComponent) Update(msg tea.Msg) tea.Cmd {
 		m.topics.panes.unsubscribed.page = m.topics.list.Paginator.Page
 	}
 	m.topics.selected = m.indexForPane(m.topics.panes.active, m.topics.list.Index())
-	return tea.Batch(fcmd, cmd, m.connections.ListenStatus())
+	return tea.Batch(fcmd, tcmd, cmd, m.connections.ListenStatus())
 }
 
 // View displays the topic manager list.

--- a/update.go
+++ b/update.go
@@ -50,6 +50,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Reserve two lines for the info header at the top of the view.
 		m.ui.viewport.Height = msg.Height - 2
 		return m, nil
+	case topicToggleMsg:
+		cmd := m.handleTopicToggle(msg)
+		return m, cmd
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+up", "ctrl+k":


### PR DESCRIPTION
## Summary
- add topicToggleMsg and emit events when topic subscriptions change
- route topic events to connection handler via handleTopicToggle
- update confirm dialogs and topic views to use callbacks

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e562e1ee08324973732431255d545