### PR TITLE
refactor help component to use navigator interface

### DIFF
--- a/help_component.go
+++ b/help_component.go
@@ -10,16 +10,20 @@ import (
 
 type helpComponent struct {
 	nav     Navigator
-	ui      *uiState
+	width   *int
+	height  *int
+	elemPos *map[string]int
 	vp      viewport.Model
 	focused bool
 }
 
-func newHelpComponent(nav Navigator, ui *uiState) *helpComponent {
+func newHelpComponent(nav Navigator, width, height *int, elemPos *map[string]int) *helpComponent {
 	return &helpComponent{
-		nav: nav,
-		ui:  ui,
-		vp:  viewport.New(0, 0),
+		nav:     nav,
+		width:   width,
+		height:  height,
+		elemPos: elemPos,
+		vp:      viewport.New(0, 0),
 	}
 }
 
@@ -41,14 +45,14 @@ func (h *helpComponent) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (h *helpComponent) View() string {
-	h.ui.elemPos = map[string]int{}
+	*h.elemPos = map[string]int{}
 	h.vp.SetContent(helpText)
 	content := h.vp.View()
 	sp := -1.0
 	if h.vp.Height < lipgloss.Height(content) {
 		sp = h.vp.ScrollPercent()
 	}
-	return ui.LegendBox(content, "Help", h.ui.width-2, h.ui.height-2, ui.ColGreen, true, sp)
+	return ui.LegendBox(content, "Help", *h.width-2, *h.height-2, ui.ColGreen, true, sp)
 }
 
 func (h *helpComponent) Focus() tea.Cmd {

--- a/help_component.go
+++ b/help_component.go
@@ -9,15 +9,17 @@ import (
 )
 
 type helpComponent struct {
-	m       *model
+	nav     Navigator
+	ui      *uiState
 	vp      viewport.Model
 	focused bool
 }
 
-func newHelpComponent(m *model) *helpComponent {
+func newHelpComponent(nav Navigator, ui *uiState) *helpComponent {
 	return &helpComponent{
-		m:  m,
-		vp: viewport.New(0, 0),
+		nav: nav,
+		ui:  ui,
+		vp:  viewport.New(0, 0),
 	}
 }
 
@@ -28,7 +30,7 @@ func (h *helpComponent) Update(msg tea.Msg) tea.Cmd {
 	case tea.KeyMsg:
 		switch t.String() {
 		case "esc":
-			return h.m.setMode(h.m.previousMode())
+			return h.nav.setMode(h.nav.previousMode())
 		case "ctrl+d":
 			return tea.Quit
 		}
@@ -39,14 +41,14 @@ func (h *helpComponent) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (h *helpComponent) View() string {
-	h.m.ui.elemPos = map[string]int{}
+	h.ui.elemPos = map[string]int{}
 	h.vp.SetContent(helpText)
 	content := h.vp.View()
 	sp := -1.0
 	if h.vp.Height < lipgloss.Height(content) {
 		sp = h.vp.ScrollPercent()
 	}
-	return ui.LegendBox(content, "Help", h.m.ui.width-2, h.m.ui.height-2, ui.ColGreen, true, sp)
+	return ui.LegendBox(content, "Help", h.ui.width-2, h.ui.height-2, ui.ColGreen, true, sp)
 }
 
 func (h *helpComponent) Focus() tea.Cmd {

--- a/model_init.go
+++ b/model_init.go
@@ -201,7 +201,7 @@ func initialModel(conns *Connections) (*model, error) {
 		ui:          initUI(order),
 		layout:      initLayout(),
 	}
-	m.help = newHelpComponent(m)
+	m.help = newHelpComponent(m, &m.ui)
 	m.confirm = newConfirmComponent(m)
 	connComp := newConnectionsComponent(m)
 	topicsComp := newTopicsComponent(m)

--- a/model_init.go
+++ b/model_init.go
@@ -201,7 +201,7 @@ func initialModel(conns *Connections) (*model, error) {
 		ui:          initUI(order),
 		layout:      initLayout(),
 	}
-	m.help = newHelpComponent(m, &m.ui)
+	m.help = newHelpComponent(m, &m.ui.width, &m.ui.height, &m.ui.elemPos)
 	m.confirm = newConfirmComponent(m)
 	connComp := newConnectionsComponent(m)
 	topicsComp := newTopicsComponent(m)

--- a/navigator.go
+++ b/navigator.go
@@ -1,0 +1,9 @@
+package emqutiti
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Navigator defines minimal navigation features for components.
+type Navigator interface {
+	setMode(appMode) tea.Cmd
+	previousMode() appMode
+}


### PR DESCRIPTION
## Summary
- introduce Navigator interface for simple mode operations
- refactor help component to depend on Navigator and ui state
- update model initialization for new help component signature

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e60c2d9908324abaa398ddb5d4272