### PR TITLE
refactor confirm component callbacks

### DIFF
--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -109,8 +109,8 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 			m.history.items[idx].isMarkedForDeletion = &v
 		}
 	}
-	m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-	m.startConfirm("Delete selected messages? [y/n]", "", func() tea.Cmd {
+	rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+	m.startConfirm("Delete selected messages? [y/n]", "", rf, func() tea.Cmd {
 		for i := len(m.history.items) - 1; i >= 0; i-- {
 			it := m.history.items[i]
 			if it.isMarkedForDeletion != nil && *it.isMarkedForDeletion {
@@ -141,11 +141,10 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 		}
 		m.history.selectionAnchor = -1
 		return nil
-	})
-	m.confirm.cancel = func() {
+	}, func() {
 		for i := range m.history.items {
 			m.history.items[i].isMarkedForDeletion = nil
 		}
-	}
+	})
 	return nil
 }

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -65,13 +65,13 @@ func (m *model) handleEnterKey() tea.Cmd {
 func (m *model) handleDeleteTopicKey() tea.Cmd {
 	idx := m.topics.selected
 	name := m.topics.items[idx].title
-	m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-	m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() tea.Cmd {
+	rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+	m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
 		cmd := m.removeTopic(idx)
 		if m.currentMode() == modeTopics {
 			m.rebuildActiveTopicList()
 		}
 		return cmd
-	})
+	}, nil)
 	return nil
 }

--- a/confirm_component.go
+++ b/confirm_component.go
@@ -10,26 +10,23 @@ import (
 type confirmComponent struct {
 	m *model
 
-	prompt string
-	info   string
-	action func() tea.Cmd
-	cancel func()
-
-	returnFocus string
+	prompt      string
+	info        string
+	action      func() tea.Cmd
+	cancel      func()
+	returnFocus func() tea.Cmd
 	focused     bool
 }
 
-func newConfirmComponent(nav navigator) *confirmComponent {
-	return &confirmComponent{m: nav.(*model)}
+func newConfirmComponent(nav navigator, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) *confirmComponent {
+	return &confirmComponent{m: nav.(*model), returnFocus: returnFocus, action: action, cancel: cancel}
 }
 
 func (c *confirmComponent) Init() tea.Cmd { return nil }
 
-func (c *confirmComponent) start(prompt, info string, action func() tea.Cmd) {
+func (c *confirmComponent) start(prompt, info string) {
 	c.prompt = prompt
 	c.info = info
-	c.action = action
-	c.cancel = nil
 	_ = c.m.setMode(modeConfirmDelete)
 }
 
@@ -53,9 +50,9 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 			if acmd != nil {
 				cmds = append(cmds, acmd)
 			}
-			if c.returnFocus != "" {
-				cmds = append(cmds, c.m.setFocus(c.returnFocus))
-				c.returnFocus = ""
+			if c.returnFocus != nil {
+				cmds = append(cmds, c.returnFocus())
+				c.returnFocus = nil
 			} else {
 				c.m.scrollToFocused()
 			}
@@ -67,9 +64,9 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 			}
 			cmd := c.m.setMode(c.m.previousMode())
 			cmds := []tea.Cmd{cmd, c.m.connections.ListenStatus()}
-			if c.returnFocus != "" {
-				cmds = append(cmds, c.m.setFocus(c.returnFocus))
-				c.returnFocus = ""
+			if c.returnFocus != nil {
+				cmds = append(cmds, c.returnFocus())
+				c.returnFocus = nil
 			} else {
 				c.m.scrollToFocused()
 			}

--- a/connections_component.go
+++ b/connections_component.go
@@ -212,13 +212,13 @@ func (c *connectionsComponent) Update(msg tea.Msg) tea.Cmd {
 			if i >= 0 {
 				name := m.connections.manager.Profiles[i].Name
 				info := "This also deletes history and traces"
-				m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), info, func() tea.Cmd {
+				rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+				m.startConfirm(fmt.Sprintf("Delete broker '%s'? [y/n]", name), info, rf, func() tea.Cmd {
 					m.connections.manager.DeleteConnection(i)
 					m.connections.manager.refreshList()
 					m.refreshConnectionItems()
 					return nil
-				})
+				}, nil)
 				return m.connections.ListenStatus()
 			}
 		case "x":

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -233,10 +233,10 @@ func TestDeleteErrorFeedback(t *testing.T) {
 	_ = db.Close()
 	m.history.store = &HistoryStore{db: db}
 	m.handleDeleteHistoryKey()
-	if m.confirm.action == nil {
+	if m.currentMode() != modeConfirmDelete {
 		t.Fatalf("confirmAction not set")
 	}
-	m.confirm.action()
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
 	if len(m.history.items) != 2 {
 		t.Fatalf("expected original item plus error log, got %d items", len(m.history.items))
 	}

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -35,8 +35,10 @@ func (m *model) historyIndexAt(y int) int {
 }
 
 // startConfirm displays a confirmation dialog and runs the action on accept.
-func (m *model) startConfirm(prompt, info string, action func() tea.Cmd) {
-	m.confirm.start(prompt, info, action)
+func (m *model) startConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
+	m.confirm = newConfirmComponent(m, returnFocus, action, cancel)
+	m.confirm.start(prompt, info)
+	m.components[modeConfirmDelete] = m.confirm
 }
 
 // startHistoryFilter opens the history filter form.

--- a/model_init.go
+++ b/model_init.go
@@ -202,7 +202,7 @@ func initialModel(conns *Connections) (*model, error) {
 		layout:      initLayout(),
 	}
 	m.help = newHelpComponent(m, &m.ui.width, &m.ui.height, &m.ui.elemPos)
-	m.confirm = newConfirmComponent(m)
+	m.confirm = newConfirmComponent(m, nil, nil, nil)
 	connComp := newConnectionsComponent(m)
 	topicsComp := newTopicsComponent(m)
 	m.payloads = newPayloadsComponent(m)
@@ -210,7 +210,7 @@ func initialModel(conns *Connections) (*model, error) {
 	m.topics.panes.unsubscribed.m = m
 
 	// Collect focusable elements from model and components.
-	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, m.help}
+	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, m.help, m.confirm}
 	m.focusables = map[string]Focusable{}
 	for _, p := range providers {
 		for id, f := range p.Focusables() {

--- a/model_traces.go
+++ b/model_traces.go
@@ -49,12 +49,12 @@ func (m *model) startTrace(index int) {
 	}
 	exists, err := tracerHasData(item.cfg.Profile, item.key)
 	if err == nil && exists {
-		m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), "existing trace data will be removed", func() tea.Cmd {
+		rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+		m.startConfirm(fmt.Sprintf("Overwrite trace '%s'? [y/n]", item.key), "existing trace data will be removed", rf, func() tea.Cmd {
 			tracerClearData(item.cfg.Profile, item.key)
 			m.forceStartTrace(index)
 			return nil
-		})
+		}, nil)
 		return
 	}
 	m.forceStartTrace(index)

--- a/topic_delete_test.go
+++ b/topic_delete_test.go
@@ -16,9 +16,6 @@ func TestDeleteTopic(t *testing.T) {
 	if cmd == nil || m.currentMode() != modeConfirmDelete {
 		t.Fatalf("expected confirm delete mode")
 	}
-	if m.confirm.action == nil {
-		t.Fatalf("confirm action not set")
-	}
 	if len(m.topics.items) != 2 {
 		t.Fatalf("unexpected topics before confirm: %#v", m.topics.items)
 	}

--- a/topics_component.go
+++ b/topics_component.go
@@ -56,12 +56,12 @@ func (c *topicsComponent) Update(msg tea.Msg) tea.Cmd {
 			i := m.topics.selected
 			if i >= 0 && i < len(m.topics.items) {
 				name := m.topics.items[i].title
-				m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() tea.Cmd {
+				rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+				m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
 					cmd := m.removeTopic(i)
 					m.rebuildActiveTopicList()
 					return cmd
-				})
+				}, nil)
 				return m.connections.ListenStatus()
 			}
 		case "enter", " ":

--- a/update_client.go
+++ b/update_client.go
@@ -198,14 +198,14 @@ func (m *model) handleTopicsClick(msg tea.MouseMsg) tea.Cmd {
 		return cmd
 	} else if msg.Type == tea.MouseRight {
 		name := m.topics.items[idx].title
-		m.confirm.returnFocus = m.ui.focusOrder[m.ui.focusIndex]
-		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", func() tea.Cmd {
+		rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+		m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
 			cmd := m.removeTopic(idx)
 			if m.currentMode() == modeTopics {
 				m.rebuildActiveTopicList()
 			}
 			return cmd
-		})
+		}, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- accept return focus and confirmation callbacks when constructing the confirm component
- build confirm dialogs through `startConfirm` without direct field access
- update callers to provide focus restoration

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e66066e8c832496664ef884b9873f