### PR TITLE
refactor: inject payload interfaces and own topic state

### DIFF
--- a/model.go
+++ b/model.go
@@ -89,7 +89,7 @@ type model struct {
 
 	connections connectionsState
 	history     historyState
-	topics      topicsState
+	topics      *topicsComponent
 	message     messageState
 	traces      tracesState
 	payloads    *payloadsComponent

--- a/model_init.go
+++ b/model_init.go
@@ -189,13 +189,11 @@ func initialModel(conns *Connections) (*model, error) {
 	order := append([]string(nil), focusByMode[modeClient]...)
 	cs, loadErr := initConnections(conns)
 	hs, hDel := initHistory()
-	ts := initTopics()
 	ms := initMessage()
 	tr, traceDel := initTraces()
 	m := &model{
 		connections: cs,
 		history:     hs,
-		topics:      ts,
 		message:     ms,
 		traces:      tr,
 		ui:          initUI(order),
@@ -205,7 +203,8 @@ func initialModel(conns *Connections) (*model, error) {
 	m.confirm = newConfirmComponent(m, nil, nil, nil)
 	connComp := newConnectionsComponent(m, m.connectionsAPI())
 	topicsComp := newTopicsComponent(m)
-	m.payloads = newPayloadsComponent(m)
+	m.topics = topicsComp
+	m.payloads = newPayloadsComponent(m, m.topics, &m.message, &m.connections)
 	m.topics.panes.subscribed.m = m
 	m.topics.panes.unsubscribed.m = m
 


### PR DESCRIPTION
## Summary
- decouple payloads component from model by injecting topic, payload, and status interfaces
- move topics state into a struct owned by the topics component and update model wiring

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e6b8e30a08324b7577697dce98dd8