### PR TITLE
refactor topics component to use interface

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -202,11 +202,9 @@ func initialModel(conns *Connections) (*model, error) {
 	m.help = newHelpComponent(m, &m.ui.width, &m.ui.height, &m.ui.elemPos)
 	m.confirm = newConfirmComponent(m, nil, nil, nil)
 	connComp := newConnectionsComponent(m, m.connectionsAPI())
-	topicsComp := newTopicsComponent(m)
+	topicsComp := newTopicsComponent(m.topicsAPI())
 	m.topics = topicsComp
 	m.payloads = newPayloadsComponent(m, m.topics, &m.message, &m.connections)
-	m.topics.panes.subscribed.m = m
-	m.topics.panes.unsubscribed.m = m
 
 	// Collect focusable elements from model and components.
 	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, m.help, m.confirm}

--- a/model_topics.go
+++ b/model_topics.go
@@ -26,10 +26,12 @@ type chipBound struct {
 	width, height int
 }
 
+type paneManager interface{ SetActivePane(int) }
+
 type paneState struct {
 	sel     int
 	page    int
-	m       *model
+	m       paneManager
 	index   int
 	focused bool
 }
@@ -37,7 +39,7 @@ type paneState struct {
 func (p *paneState) Focus() {
 	p.focused = true
 	if p.m != nil {
-		p.m.setActivePane(p.index)
+		p.m.SetActivePane(p.index)
 	}
 }
 
@@ -177,6 +179,9 @@ func (m *model) setActivePane(idx int) {
 	m.topics.panes.active = idx
 	m.rebuildActiveTopicList()
 }
+
+// SetActivePane exposes setActivePane for components needing to switch panes.
+func (m *model) SetActivePane(idx int) { m.setActivePane(idx) }
 
 // toggleTopic toggles the subscription state of the topic at index and emits an event.
 func (m *model) toggleTopic(index int) tea.Cmd {

--- a/topics_api.go
+++ b/topics_api.go
@@ -1,0 +1,45 @@
+package emqutiti
+
+import (
+	"github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type TopicsAPI interface {
+	navigator
+	SetFocus(id string) tea.Cmd
+	FocusedID() string
+	StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func())
+	RemoveTopic(index int) tea.Cmd
+	RebuildActiveTopicList()
+	ToggleTopic(index int) tea.Cmd
+	IndexForPane(pane, idx int) int
+	SubscribedItems() []list.Item
+	UnsubscribedItems() []list.Item
+	ResetElemPos()
+	SetElemPos(id string, pos int)
+	OverlayHelp(view string) string
+	ListenStatus() tea.Cmd
+	SetActivePane(idx int)
+}
+
+type topicsModel struct{ *model }
+
+func (m *model) topicsAPI() TopicsAPI { return &topicsModel{m} }
+
+func (t *topicsModel) SetFocus(id string) tea.Cmd { return t.setFocus(id) }
+func (t *topicsModel) FocusedID() string          { return t.ui.focusOrder[t.ui.focusIndex] }
+func (t *topicsModel) StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
+	t.startConfirm(prompt, info, returnFocus, action, cancel)
+}
+func (t *topicsModel) RemoveTopic(index int) tea.Cmd  { return t.removeTopic(index) }
+func (t *topicsModel) RebuildActiveTopicList()        { t.rebuildActiveTopicList() }
+func (t *topicsModel) ToggleTopic(index int) tea.Cmd  { return t.toggleTopic(index) }
+func (t *topicsModel) IndexForPane(pane, idx int) int { return t.indexForPane(pane, idx) }
+func (t *topicsModel) SubscribedItems() []list.Item   { return t.subscribedItems() }
+func (t *topicsModel) UnsubscribedItems() []list.Item { return t.unsubscribedItems() }
+func (t *topicsModel) ResetElemPos()                  { t.ui.elemPos = map[string]int{} }
+func (t *topicsModel) SetElemPos(id string, pos int)  { t.ui.elemPos[id] = pos }
+func (t *topicsModel) OverlayHelp(view string) string { return t.overlayHelp(view) }
+func (t *topicsModel) ListenStatus() tea.Cmd          { return t.connections.ListenStatus() }
+func (t *topicsModel) SetActivePane(idx int)          { t.setActivePane(idx) }


### PR DESCRIPTION
## Summary
- abstract topic UI interactions behind TopicsAPI
- refactor topics component to use TopicsAPI and expose selection methods
- add SetActivePane wrapper and paneManager interface

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e7011d7a08324b3449adfac451c0f