### PR TITLE
refactor: add HistoryStore interface

### DIFF
--- a/history_component.go
+++ b/history_component.go
@@ -2,7 +2,6 @@ package emqutiti
 
 import (
 	"strings"
-	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/viewport"
@@ -12,23 +11,10 @@ import (
 	"github.com/marang/emqutiti/ui"
 )
 
-type historyAppender interface {
-	Add(Message)
-}
-
-type historyQuerier interface {
-	Search(archived bool, topics []string, start, end time.Time, payload string) []Message
-}
-
-type historyStore interface {
-	historyAppender
-	historyQuerier
-}
-
 type historyState struct {
 	list            list.Model
 	items           []historyItem
-	store           *HistoryStore
+	store           HistoryStore
 	selectionAnchor int
 	showArchived    bool
 	filterForm      *historyFilterForm

--- a/history_delegate.go
+++ b/history_delegate.go
@@ -17,7 +17,7 @@ import (
 const historyPreviewLimit = 256
 
 // historyDelegate renders history items with two lines and supports highlighting
-// selected entries.
+// selected entries. It has no direct dependency on the application model.
 type historyDelegate struct{}
 
 // Height returns the fixed height for history entries.

--- a/history_util.go
+++ b/history_util.go
@@ -22,7 +22,7 @@ func messagesToHistoryItems(msgs []Message) ([]historyItem, []list.Item) {
 }
 
 // applyHistoryFilter parses the query and retrieves matching messages from the store.
-func applyHistoryFilter(q string, store historyQuerier, archived bool) ([]historyItem, []list.Item) {
+func applyHistoryFilter(q string, store HistoryStore, archived bool) ([]historyItem, []list.Item) {
 	if store == nil {
 		return nil, nil
 	}

--- a/history_view_test.go
+++ b/history_view_test.go
@@ -97,7 +97,7 @@ func TestHistoryBoxLayout(t *testing.T) {
 func TestHistoryFilterDisplayedInsideBox(t *testing.T) {
 	m, _ := initialModel(nil)
 	m.history.filterQuery = "topic=foo"
-	m.history.store = &HistoryStore{}
+	m.history.store = &historyStore{}
 	m.appendHistory("foo", "bar", "pub", "")
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
 	view := m.viewClient()
@@ -136,7 +136,7 @@ func TestHistoryFilterDisplayedInsideBox(t *testing.T) {
 // Test that the history label reports total and filtered message counts.
 func TestHistoryLabelCounts(t *testing.T) {
 	m, _ := initialModel(nil)
-	m.history.store = &HistoryStore{}
+	m.history.store = &historyStore{}
 	m.appendHistory("foo", "bar", "pub", "")
 	m.appendHistory("bar", "baz", "sub", "")
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
@@ -162,7 +162,7 @@ func TestHistoryFilterLineWidth(t *testing.T) {
 	m, _ := initialModel(nil)
 	long := strings.Repeat("x", 100)
 	m.history.filterQuery = "topic=" + long
-	m.history.store = &HistoryStore{}
+	m.history.store = &historyStore{}
 	m.appendHistory("foo", "bar", "pub", "")
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
 	view := m.viewClient()
@@ -194,7 +194,7 @@ func TestHistoryFilterLineWidth(t *testing.T) {
 // Test that the history help legend remains visible after applying a filter.
 func TestHistoryHelpVisibleWithFilter(t *testing.T) {
 	m, _ := initialModel(nil)
-	m.history.store = &HistoryStore{}
+	m.history.store = &historyStore{}
 	m.history.filterQuery = "topic=foo"
 	m.appendHistory("foo", "bar", "pub", "")
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 30})
@@ -211,7 +211,7 @@ func TestArchiveErrorFeedback(t *testing.T) {
 	hi := historyItem{timestamp: time.Now(), topic: "foo", payload: "bar", kind: "pub"}
 	m.history.items = []historyItem{hi}
 	m.history.list.SetItems([]list.Item{hi})
-	m.history.store = &HistoryStore{}
+	m.history.store = &historyStore{}
 	m.handleArchiveKey()
 	if len(m.history.items) != 2 {
 		t.Fatalf("expected original item plus error log, got %d items", len(m.history.items))
@@ -231,7 +231,7 @@ func TestDeleteErrorFeedback(t *testing.T) {
 	m.history.list.Select(0)
 	db, _ := badger.Open(badger.DefaultOptions("").WithInMemory(true))
 	_ = db.Close()
-	m.history.store = &HistoryStore{db: db}
+	m.history.store = &historyStore{db: db}
 	m.handleDeleteHistoryKey()
 	if m.currentMode() != modeConfirmDelete {
 		t.Fatalf("confirmAction not set")

--- a/historystore_archive_test.go
+++ b/historystore_archive_test.go
@@ -7,10 +7,10 @@ import (
 )
 
 func TestArchiveAndSearch(t *testing.T) {
-	hs := &HistoryStore{}
+	hs := &historyStore{}
 	ts := time.Now()
 	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub"}
-	hs.Add(msg)
+	hs.Append(msg)
 	key := fmt.Sprintf("%s/%020d", msg.Topic, msg.Timestamp.UnixNano())
 	if err := hs.Archive(key); err != nil {
 		t.Fatalf("Archive failed: %v", err)

--- a/historystore_search_test.go
+++ b/historystore_search_test.go
@@ -11,9 +11,9 @@ func TestHistoryStoreSearch(t *testing.T) {
 	now := time.Now()
 
 	t.Run("active", func(t *testing.T) {
-		hs := &HistoryStore{}
-		hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
-		hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
+		hs := &historyStore{}
+		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
+		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
 
 		res := hs.Search(false, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {
@@ -32,9 +32,9 @@ func TestHistoryStoreSearch(t *testing.T) {
 	})
 
 	t.Run("archived", func(t *testing.T) {
-		hs := &HistoryStore{}
-		hs.Add(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true})
-		hs.Add(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true})
+		hs := &historyStore{}
+		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true})
+		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true})
 
 		res := hs.Search(true, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -59,11 +59,11 @@ func TestHandleHistorySelectionShift(t *testing.T) {
 
 func TestFilterHistoryList(t *testing.T) {
 	m, _ := initialModel(nil)
-	hs := &HistoryStore{}
+	hs := &historyStore{}
 	m.history.store = hs
 	ts := time.Now()
-	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Add(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
 
 	m.history.list.SetFilteringEnabled(true)
 	m.history.list.SetFilterText("topic=foo")

--- a/update_history.go
+++ b/update_history.go
@@ -37,8 +37,7 @@ func (m *model) appendHistory(topic, payload, kind, logText string) {
 	}
 	hi := historyItem{timestamp: ts, topic: topic, payload: text, kind: kind, archived: false}
 	if m.history.store != nil {
-		var app historyAppender = m.history.store
-		app.Add(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false})
+		m.history.store.Append(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false})
 	}
 	if !m.history.showArchived {
 		if m.history.filterQuery != "" {

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -11,10 +11,10 @@ import (
 // Test that applying history filters populates the list with results.
 func TestUpdateHistoryFilter(t *testing.T) {
 	m, _ := initialModel(nil)
-	hs := &HistoryStore{}
+	hs := &historyStore{}
 	m.history.store = hs
 	ts := time.Now()
-	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
 
 	m.startHistoryFilter()
 	m.history.filterForm.topic.SetValue("foo")
@@ -33,11 +33,11 @@ func TestUpdateHistoryFilter(t *testing.T) {
 // Test that filtered results persist after the next update cycle.
 func TestHistoryFilterPersists(t *testing.T) {
 	m, _ := initialModel(nil)
-	hs := &HistoryStore{}
+	hs := &historyStore{}
 	m.history.store = hs
 	ts := time.Now()
-	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Add(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
 
 	m.startHistoryFilter()
 	m.history.filterForm.topic.SetValue("foo")
@@ -64,11 +64,11 @@ func TestHistoryFilterPersists(t *testing.T) {
 // Test that filtering updates the history label counts.
 func TestHistoryFilterUpdatesCounts(t *testing.T) {
 	m, _ := initialModel(nil)
-	hs := &HistoryStore{}
+	hs := &historyStore{}
 	m.history.store = hs
 	ts := time.Now()
-	hs.Add(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Add(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
 
 	m.startHistoryFilter()
 	m.history.filterForm.topic.SetValue("foo")


### PR DESCRIPTION
## Summary
- define a HistoryStore interface with append, search, archive and delete operations
- refactor history component to use the HistoryStore abstraction
- clarify history delegate independence from the application model

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688e732429f8832492d68a2e8e9760b1