### PR TITLE
Add trace store interface and component wrapper

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -205,9 +205,10 @@ func initialModel(conns *Connections) (*model, error) {
 	topicsComp := newTopicsComponent(m.topicsAPI())
 	m.topics = topicsComp
 	m.payloads = newPayloadsComponent(m, m.topics, &m.message, &m.connections)
+	tracesComp := newTracesComponent(m, m.tracesStore())
 
 	// Collect focusable elements from model and components.
-	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, m.help, m.confirm}
+	providers := []FocusableSet{m, connComp, topicsComp, m.payloads, tracesComp, m.help, m.confirm}
 	m.focusables = map[string]Focusable{}
 	for _, p := range providers {
 		for id, f := range p.Focusables() {
@@ -231,7 +232,7 @@ func initialModel(conns *Connections) (*model, error) {
 		modeConfirmDelete:  m.confirm,
 		modeTopics:         topicsComp,
 		modePayloads:       m.payloads,
-		modeTracer:         component{update: m.updateTraces, view: m.viewTraces},
+		modeTracer:         tracesComp,
 		modeEditTrace:      component{update: m.updateTraceForm, view: m.viewTraceForm},
 		modeViewTrace:      component{update: m.updateTraceView, view: m.viewTraceMessages},
 		modeHistoryFilter:  component{update: m.updateHistoryFilter, view: m.viewHistoryFilter},

--- a/traces_api.go
+++ b/traces_api.go
@@ -1,0 +1,38 @@
+package emqutiti
+
+// TraceStore defines persistence and messaging operations for traces.
+type TraceStore interface {
+	LoadTraces() map[string]TracerConfig
+	SaveTraces(map[string]TracerConfig)
+	AddTrace(TracerConfig)
+	RemoveTrace(string)
+	Messages(profile, key string) ([]TracerMessage, error)
+	HasData(profile, key string) (bool, error)
+	ClearData(profile, key string) error
+	LoadCounts(profile, key string, topics []string) (map[string]int, error)
+}
+
+// fileTraceStore implements TraceStore using on-disk state and the
+// tracer message database. It provides the default application
+// behaviour but can be replaced for testing.
+type fileTraceStore struct{}
+
+func (fileTraceStore) LoadTraces() map[string]TracerConfig     { return loadTraces() }
+func (fileTraceStore) SaveTraces(data map[string]TracerConfig) { saveTraces(data) }
+func (fileTraceStore) AddTrace(cfg TracerConfig)               { addTrace(cfg) }
+func (fileTraceStore) RemoveTrace(key string)                  { removeTrace(key) }
+func (fileTraceStore) Messages(profile, key string) ([]TracerMessage, error) {
+	return tracerMessages(profile, key)
+}
+func (fileTraceStore) HasData(profile, key string) (bool, error) {
+	return tracerHasData(profile, key)
+}
+func (fileTraceStore) ClearData(profile, key string) error {
+	return tracerClearData(profile, key)
+}
+func (fileTraceStore) LoadCounts(profile, key string, topics []string) (map[string]int, error) {
+	return tracerLoadCounts(profile, key, topics)
+}
+
+// tracesStore exposes the default TraceStore implementation.
+func (m *model) tracesStore() TraceStore { return fileTraceStore{} }

--- a/traces_component_new.go
+++ b/traces_component_new.go
@@ -1,0 +1,32 @@
+package emqutiti
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// tracesComponent wraps the existing trace functionality so that it satisfies
+// the Component interface. It delegates update and view logic to the model
+// but allows tests to supply custom implementations of trace persistence.
+type tracesComponent struct {
+	m     *model
+	store TraceStore
+}
+
+// newTracesComponent creates a tracesComponent using the provided navigator
+// and TraceStore implementation. The navigator is expected to be the model
+// itself, which holds the tracing state.
+func newTracesComponent(nav navigator, store TraceStore) *tracesComponent {
+	return &tracesComponent{m: nav.(*model), store: store}
+}
+
+func (t *tracesComponent) Init() tea.Cmd { return nil }
+
+func (t *tracesComponent) Update(msg tea.Msg) tea.Cmd { return t.m.updateTraces(msg) }
+
+func (t *tracesComponent) View() string { return t.m.viewTraces() }
+
+func (t *tracesComponent) Focus() tea.Cmd { return nil }
+
+func (t *tracesComponent) Blur() {}
+
+// Focusables satisfies the FocusableSet interface but the trace list focusable
+// is provided by the model's base Focusables so this returns an empty map.
+func (t *tracesComponent) Focusables() map[string]Focusable { return map[string]Focusable{} }


### PR DESCRIPTION
## Summary
- add TraceStore interface for trace persistence and messaging
- create newTracesComponent taking Navigator and TraceStore
- wire traces component into model initialization

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f098d747883248b6e0bc43524bfe7