### PR TITLE
refactor connection helpers

### DIFF
--- a/client_keys.go
+++ b/client_keys.go
@@ -68,7 +68,7 @@ func (m *model) handleDisconnectKey() tea.Cmd {
 	if m.mqttClient != nil {
 		m.mqttClient.Disconnect()
 		m.connections.SetDisconnected(m.connections.active, "")
-		m.refreshConnectionItems()
+		m.connections.RefreshConnectionItems()
 		m.connections.connection = ""
 		m.connections.active = ""
 		m.mqttClient = nil

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -85,7 +85,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 		if err := m.connections.manager.LoadProfiles(""); err != nil {
 			m.history.Append("", err.Error(), "log", err.Error())
 		}
-		m.refreshConnectionItems()
+		m.connections.RefreshConnectionItems()
 		m.history.SaveCurrent()
 		m.traces.savePlannedTraces()
 		return m.setMode(modeConnections)

--- a/connections_component.go
+++ b/connections_component.go
@@ -85,6 +85,18 @@ func (c *connectionsState) SendStatus(msg string) {
 // FlushStatus discards any pending status messages.
 func (c *connectionsState) FlushStatus() { flushStatus(c.statusChan) }
 
+// RefreshConnectionItems rebuilds the connections list to show status
+// information.
+func (c *connectionsState) RefreshConnectionItems() {
+	items := []list.Item{}
+	for _, p := range c.manager.Profiles {
+		status := c.manager.Statuses[p.Name]
+		detail := c.manager.Errors[p.Name]
+		items = append(items, connectionItem{title: p.Name, status: status, detail: detail})
+	}
+	c.manager.ConnectionsList.SetItems(items)
+}
+
 // connectionsComponent implements the Component interface for managing brokers.
 type connectionsComponent struct {
 	nav navigator

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -1,7 +1,6 @@
 package emqutiti
 
 import (
-	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"time"
 )
@@ -70,29 +69,6 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	hf := newHistoryFilterForm(topics, topic, payload, start, end)
 	m.history.filterForm = &hf
 	return m.setMode(modeHistoryFilter)
-}
-
-// subscribeActiveTopics subscribes the MQTT client to all currently active topics.
-func (m *model) subscribeActiveTopics() {
-	if m.mqttClient == nil {
-		return
-	}
-	for _, t := range m.topics.items {
-		if t.subscribed {
-			m.mqttClient.Subscribe(t.title, 0, nil)
-		}
-	}
-}
-
-// refreshConnectionItems rebuilds the connections list to show status information.
-func (m *model) refreshConnectionItems() {
-	items := []list.Item{}
-	for _, p := range m.connections.manager.Profiles {
-		status := m.connections.manager.Statuses[p.Name]
-		detail := m.connections.manager.Errors[p.Name]
-		items = append(items, connectionItem{title: p.Name, status: status, detail: detail})
-	}
-	m.connections.manager.ConnectionsList.SetItems(items)
 }
 
 // setMode updates the current mode and focus order.

--- a/update_client.go
+++ b/update_client.go
@@ -15,11 +15,11 @@ func (m *model) handleStatusMessage(msg statusMessage) tea.Cmd {
 	m.history.Append("", string(msg), "log", string(msg))
 	if strings.HasPrefix(string(msg), "Connected") && m.connections.active != "" {
 		m.connections.SetConnected(m.connections.active)
-		m.refreshConnectionItems()
-		m.subscribeActiveTopics()
+		m.connections.RefreshConnectionItems()
+		m.connectionsAPI().SubscribeActiveTopics()
 	} else if strings.HasPrefix(string(msg), "Connection lost") && m.connections.active != "" {
 		m.connections.SetDisconnected(m.connections.active, "")
-		m.refreshConnectionItems()
+		m.connections.RefreshConnectionItems()
 	}
 	return m.connections.ListenStatus()
 }

--- a/update_form.go
+++ b/update_form.go
@@ -32,7 +32,7 @@ func (m *model) updateForm(msg tea.Msg) tea.Cmd {
 			} else {
 				m.connections.manager.AddConnection(p)
 			}
-			m.refreshConnectionItems()
+			m.connections.RefreshConnectionItems()
 			cmd := m.setMode(modeConnections)
 			m.connections.form = nil
 			return cmd


### PR DESCRIPTION
## Summary
- move connection list rebuild into connections component
- add API for subscribing active topics
- update callers to use new component methods

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f241c1870832489ca4e58b26fcf61