### PR TITLE
refactor: extract message editor component

### DIFF
--- a/message_component.go
+++ b/message_component.go
@@ -1,0 +1,66 @@
+package emqutiti
+
+import (
+	"github.com/charmbracelet/bubbles/textarea"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/ui"
+)
+
+// messageState holds the textarea model for composing messages.
+type messageState struct {
+	input textarea.Model
+}
+
+func (m *messageState) setPayload(payload string) { m.input.SetValue(payload) }
+
+// messageComponent implements Component for the message editor.
+type messageComponent struct {
+	*messageState
+	m *model
+}
+
+func newMessageComponent(m *model, ms messageState) *messageComponent {
+	return &messageComponent{messageState: &ms, m: m}
+}
+
+func (c *messageComponent) Init() tea.Cmd { return nil }
+
+// Update handles textarea updates when editing messages.
+func (c *messageComponent) Update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	c.input, cmd = c.input.Update(msg)
+	return cmd
+}
+
+// View renders the message editor box.
+func (c *messageComponent) View() string {
+	msgContent := c.input.View()
+	msgLines := c.input.LineCount()
+	msgHeight := c.m.layout.message.height
+	msgSP := -1.0
+	if msgLines > msgHeight {
+		off := c.input.Line() - msgHeight + 1
+		if off < 0 {
+			off = 0
+		}
+		maxOff := msgLines - msgHeight
+		if off > maxOff {
+			off = maxOff
+		}
+		if maxOff > 0 {
+			msgSP = float64(off) / float64(maxOff)
+		}
+	}
+	focused := c.m.ui.focusOrder[c.m.ui.focusIndex] == idMessage
+	return ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", c.m.ui.width-2, msgHeight, ui.ColBlue, focused, msgSP)
+}
+
+func (c *messageComponent) Focus() tea.Cmd { return c.input.Focus() }
+
+func (c *messageComponent) Blur() { c.input.Blur() }
+
+// Focusables exposes focusable elements for the message component.
+func (c *messageComponent) Focusables() map[string]Focusable {
+	return map[string]Focusable{idMessage: adapt(&c.input)}
+}

--- a/model.go
+++ b/model.go
@@ -90,7 +90,7 @@ type model struct {
 	connections connectionsState
 	history     *historyComponent
 	topics      *topicsComponent
-	message     messageState
+	message     *messageComponent
 	traces      *tracesComponent
 	payloads    *payloadsComponent
 	help        *helpComponent
@@ -116,7 +116,6 @@ func (m *model) Focusables() map[string]Focusable {
 	return map[string]Focusable{
 		idTopics:    &nullFocusable{},
 		idTopic:     adapt(&m.topics.input),
-		idMessage:   adapt(&m.message.input),
 		idHistory:   &nullFocusable{},
 		idTraceList: &nullFocusable{},
 	}

--- a/model_init.go
+++ b/model_init.go
@@ -193,23 +193,24 @@ func initialModel(conns *Connections) (*model, error) {
 	tr, traceDel := initTraces()
 	m := &model{
 		connections: cs,
-		message:     ms,
 		ui:          initUI(order),
 		layout:      initLayout(),
 	}
 	historyComp := newHistoryComponent(m, hs)
 	m.history = historyComp
+	msgComp := newMessageComponent(m, ms)
+	m.message = msgComp
 	m.help = newHelpComponent(m, &m.ui.width, &m.ui.height, &m.ui.elemPos)
 	m.confirm = newConfirmComponent(m, nil, nil, nil)
 	connComp := newConnectionsComponent(m, m.connectionsAPI())
 	topicsComp := newTopicsComponent(m)
 	m.topics = topicsComp
-	m.payloads = newPayloadsComponent(m, m.topics, &m.message, &m.connections)
+	m.payloads = newPayloadsComponent(m, m.topics, msgComp, &m.connections)
 	tracesComp := newTracesComponent(m, tr, m.tracesStore())
 	m.traces = tracesComp
 
 	// Collect focusable elements from model and components.
-	providers := []FocusableSet{m, connComp, historyComp, topicsComp, m.payloads, tracesComp, m.help, m.confirm}
+	providers := []FocusableSet{m, connComp, historyComp, topicsComp, msgComp, m.payloads, tracesComp, m.help, m.confirm}
 	m.focusables = map[string]Focusable{}
 	for _, p := range providers {
 		for id, f := range p.Focusables() {

--- a/model_messages.go
+++ b/model_messages.go
@@ -1,17 +1,7 @@
 package emqutiti
 
-import (
-	"github.com/charmbracelet/bubbles/textarea"
-)
-
 type payloadItem struct{ topic, payload string }
 
 func (p payloadItem) FilterValue() string { return p.topic }
 func (p payloadItem) Title() string       { return p.topic }
 func (p payloadItem) Description() string { return p.payload }
-
-type messageState struct {
-	input textarea.Model
-}
-
-func (m *messageState) setPayload(payload string) { m.input.SetValue(payload) }

--- a/update_client.go
+++ b/update_client.go
@@ -260,8 +260,9 @@ func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
 	var cmd tea.Cmd
 	m.topics.input, cmd = m.topics.input.Update(msg)
 	cmds = append(cmds, cmd)
-	m.message.input, cmd = m.message.input.Update(msg)
-	cmds = append(cmds, cmd)
+	if mCmd := m.message.Update(msg); mCmd != nil {
+		cmds = append(cmds, mCmd)
+	}
 	if vpCmd := m.updateViewport(msg); vpCmd != nil {
 		cmds = append(cmds, vpCmd)
 	}

--- a/view_client.go
+++ b/view_client.go
@@ -7,7 +7,7 @@ func (m *model) viewClient() string {
 	m.ui.elemPos = map[string]int{}
 	infoLine := m.clientInfoLine()
 	topicsBox, topicBox, bounds := m.clientTopicsSection()
-	messageBox := m.clientMessageSection()
+	messageBox := m.message.View()
 	messagesBox := m.clientHistorySection()
 
 	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)

--- a/views_client.go
+++ b/views_client.go
@@ -121,29 +121,6 @@ func (m *model) clientTopicsSection() (string, string, []chipBound) {
 	return topicsBox, topicBox, bounds
 }
 
-// clientMessageSection renders the message input box.
-func (m *model) clientMessageSection() string {
-	msgContent := m.message.input.View()
-	msgLines := m.message.input.LineCount()
-	msgHeight := m.layout.message.height
-	msgSP := -1.0
-	if msgLines > msgHeight {
-		off := m.message.input.Line() - msgHeight + 1
-		if off < 0 {
-			off = 0
-		}
-		maxOff := msgLines - msgHeight
-		if off > maxOff {
-			off = maxOff
-		}
-		if maxOff > 0 {
-			msgSP = float64(off) / float64(maxOff)
-		}
-	}
-	messageFocused := m.ui.focusOrder[m.ui.focusIndex] == idMessage
-	return ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", m.ui.width-2, msgHeight, ui.ColBlue, messageFocused, msgSP)
-}
-
 // clientHistorySection renders the history list box.
 func (m *model) clientHistorySection() string {
 	per := m.history.list.Paginator.PerPage


### PR DESCRIPTION
## Summary
- encapsulate message textarea into new `messageComponent`
- delegate update/view logic to the component and register it with the focus map
- wire the component into model initialization and client view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f25ff4758832494b572afccf2541e