### PR TITLE
decouple payload loader via LoadPayloadMsg

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -205,7 +205,7 @@ func initialModel(conns *Connections) (*model, error) {
 	connComp := newConnectionsComponent(m, m.connectionsAPI())
 	topicsComp := newTopicsComponent(m)
 	m.topics = topicsComp
-	m.payloads = newPayloadsComponent(m, m.topics, msgComp, &m.connections)
+	m.payloads = newPayloadsComponent(m, &m.connections)
 	tracesComp := newTracesComponent(m, tr, m.tracesStore())
 	m.traces = tracesComp
 

--- a/payloads_api.go
+++ b/payloads_api.go
@@ -1,0 +1,12 @@
+package emqutiti
+
+// payloadsModel defines the dependencies payloadsComponent requires from the model.
+type payloadsModel interface {
+	navigator
+	FocusedID() string
+	ResetElemPos()
+	SetElemPos(id string, pos int)
+	OverlayHelp(string) string
+}
+
+var _ payloadsModel = (*model)(nil)

--- a/update.go
+++ b/update.go
@@ -53,6 +53,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case topicToggleMsg:
 		cmd := m.handleTopicToggle(msg)
 		return m, cmd
+	case loadPayloadMsg:
+		m.topics.setTopic(msg.topic)
+		m.message.setPayload(msg.payload)
+		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+up", "ctrl+k":


### PR DESCRIPTION
## Summary
- add payloadsModel interface so the payloads component only accesses what it needs
- emit LoadPayloadMsg instead of directly poking topic/payload components
- handle LoadPayloadMsg in the root update and update initial wiring

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f2bb1de288324b56e9de89bb8ff57