### PR TITLE
refactor: centralize session persistence

### DIFF
--- a/client_keys.go
+++ b/client_keys.go
@@ -58,7 +58,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 
 // handleQuitKey saves current state and quits the application.
 func (m *model) handleQuitKey() tea.Cmd {
-	m.history.SaveCurrent()
+	m.connections.SaveCurrent(m.topics.items, m.payloads.Items())
 	m.traces.savePlannedTraces()
 	return tea.Quit
 }

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -86,7 +86,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 			m.history.Append("", err.Error(), "log", err.Error())
 		}
 		m.connections.RefreshConnectionItems()
-		m.history.SaveCurrent()
+		m.connections.SaveCurrent(m.topics.items, m.payloads.Items())
 		m.traces.savePlannedTraces()
 		return m.setMode(modeConnections)
 	case "ctrl+t":

--- a/connections_api.go
+++ b/connections_api.go
@@ -133,7 +133,11 @@ func (c *connectionsModel) HandleConnectResult(msg connectResult) {
 		}
 		c.history.list.SetItems(items)
 	}
-	c.history.RestoreState(msg.profile.Name)
+	topics, payloads := c.connections.RestoreState(msg.profile.Name)
+	c.topics.items = topics
+	c.payloads.SetItems(payloads)
+	c.topics.SortTopics()
+	c.topics.RebuildActiveTopicList()
 	c.SubscribeActiveTopics()
 	c.connections.connection = "Connected to " + brokerURL
 	c.connections.SetConnected(msg.profile.Name)

--- a/connections_component.go
+++ b/connections_component.go
@@ -97,6 +97,23 @@ func (c *connectionsState) RefreshConnectionItems() {
 	c.manager.ConnectionsList.SetItems(items)
 }
 
+// SaveCurrent persists topics and payloads for the active connection.
+func (c *connectionsState) SaveCurrent(topics []topicItem, payloads []payloadItem) {
+	if c.active == "" {
+		return
+	}
+	c.saved[c.active] = connectionData{Topics: topics, Payloads: payloads}
+	saveState(c.saved)
+}
+
+// RestoreState returns saved topics and payloads for the named connection.
+func (c *connectionsState) RestoreState(name string) ([]topicItem, []payloadItem) {
+	if data, ok := c.saved[name]; ok {
+		return data.Topics, data.Payloads
+	}
+	return []topicItem{}, []payloadItem{}
+}
+
 // connectionsComponent implements the Component interface for managing brokers.
 type connectionsComponent struct {
 	nav navigator

--- a/history_component.go
+++ b/history_component.go
@@ -144,31 +144,6 @@ func (h *historyComponent) ViewFilter() string {
 // itself is managed by the root model, so this returns an empty map.
 func (h *historyComponent) Focusables() map[string]Focusable { return map[string]Focusable{} }
 
-// SaveCurrent persists topics and payloads for the active connection.
-func (h *historyComponent) SaveCurrent() {
-	if h.m.connections.active == "" {
-		return
-	}
-	h.m.connections.saved[h.m.connections.active] = connectionData{
-		Topics:   h.m.topics.items,
-		Payloads: h.m.payloads.Items(),
-	}
-	saveState(h.m.connections.saved)
-}
-
-// RestoreState loads saved state for the named connection.
-func (h *historyComponent) RestoreState(name string) {
-	if data, ok := h.m.connections.saved[name]; ok {
-		h.m.topics.items = data.Topics
-		h.m.payloads.SetItems(data.Payloads)
-		h.m.topics.SortTopics()
-		h.m.topics.RebuildActiveTopicList()
-	} else {
-		h.m.topics.items = []topicItem{}
-		h.m.payloads.Clear()
-	}
-}
-
 // Append stores a message in the history list and optional store.
 func (h *historyComponent) Append(topic, payload, kind, logText string) {
 	ts := time.Now()


### PR DESCRIPTION
## Summary
- move topic/payload session persistence into connection state
- restore session data when connecting via connection state API
- drop history component Save/Restore and update key handlers to use connection API

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f318c620883249e10945f1f26e489