### PR TITLE
refactor traces component with API

### DIFF
--- a/view_trace_form.go
+++ b/view_trace_form.go
@@ -6,8 +6,8 @@ import (
 
 // ViewForm renders the form for new traces.
 func (t *tracesComponent) ViewForm() string {
-	t.m.ui.elemPos = map[string]int{}
+	t.api.ResetElemPos()
 	content := t.form.View()
-	view := ui.LegendBox(content, "New Trace", t.m.ui.width-2, 0, ui.ColBlue, true, -1)
-	return t.m.overlayHelp(view)
+	view := ui.LegendBox(content, "New Trace", t.api.Width()-2, 0, ui.ColBlue, true, -1)
+	return t.api.OverlayHelp(view)
 }

--- a/view_trace_messages.go
+++ b/view_trace_messages.go
@@ -9,13 +9,13 @@ import (
 
 // ViewMessages shows captured messages for a trace.
 func (t *tracesComponent) ViewMessages() string {
-	t.m.ui.elemPos = map[string]int{}
+	t.api.ResetElemPos()
 	title := fmt.Sprintf("Trace %s", t.viewKey)
 	listLines := strings.Split(t.view.View(), "\n")
 	help := ui.InfoStyle.Render("[esc] back")
 	listLines = append(listLines, help)
 	target := len(listLines)
-	minHeight := t.m.layout.trace.height + 1
+	minHeight := t.api.TraceHeight() + 1
 	if target < minHeight {
 		for len(listLines) < minHeight {
 			listLines = append(listLines, "")
@@ -23,6 +23,6 @@ func (t *tracesComponent) ViewMessages() string {
 		target = minHeight
 	}
 	content := strings.Join(listLines, "\n")
-	view := ui.LegendBox(content, title, t.m.ui.width-2, target, ui.ColBlue, true, -1)
-	return t.m.overlayHelp(view)
+	view := ui.LegendBox(content, title, t.api.Width()-2, target, ui.ColBlue, true, -1)
+	return t.api.OverlayHelp(view)
 }

--- a/view_traces.go
+++ b/view_traces.go
@@ -8,12 +8,12 @@ import (
 
 // viewTraces lists configured traces and their state.
 func (t *tracesComponent) viewTraces() string {
-	t.m.ui.elemPos = map[string]int{}
-	t.m.ui.elemPos[idTraceList] = 1
+	t.api.ResetElemPos()
+	t.api.SetElemPos(idTraceList, 1)
 	listView := t.list.View()
 	help := ui.InfoStyle.Render("[a] add  [enter] start/stop  [v] view  [del] delete  [esc] back")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
-	focused := t.m.ui.focusOrder[t.m.ui.focusIndex] == idTraceList
-	view := ui.LegendBox(content, "Traces", t.m.ui.width-2, 0, ui.ColBlue, focused, -1)
-	return t.m.overlayHelp(view)
+	focused := t.api.FocusedID() == idTraceList
+	view := ui.LegendBox(content, "Traces", t.api.Width()-2, 0, ui.ColBlue, focused, -1)
+	return t.api.OverlayHelp(view)
 }


### PR DESCRIPTION
## Summary
- introduce `TracesAPI` for trace navigation, topics, connection info, and history logging
- refactor traces component and model helpers to use `TracesAPI`
- wire root model to implement `TracesAPI` and forward to existing components

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f33b142c88324bb481f33834ca1a7