### PR TITLE
Encapsulate topic input updates inside component

### DIFF
--- a/model.go
+++ b/model.go
@@ -115,7 +115,6 @@ type model struct {
 func (m *model) Focusables() map[string]Focusable {
 	return map[string]Focusable{
 		idTopics:    &nullFocusable{},
-		idTopic:     adapt(&m.topics.input),
 		idHistory:   &nullFocusable{},
 		idTraceList: &nullFocusable{},
 	}

--- a/topics_component.go
+++ b/topics_component.go
@@ -131,11 +131,19 @@ func (c *topicsComponent) Focus() tea.Cmd { return nil }
 
 func (c *topicsComponent) Blur() {}
 
+// UpdateInput routes messages to the topic text input.
+func (c *topicsComponent) UpdateInput(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	c.input, cmd = c.input.Update(msg)
+	return cmd
+}
+
 // Focusables exposes focusable elements for the topics component.
 func (c *topicsComponent) Focusables() map[string]Focusable {
 	return map[string]Focusable{
 		idTopicsEnabled:  &c.panes.subscribed,
 		idTopicsDisabled: &c.panes.unsubscribed,
+		idTopic:          adapt(&c.input),
 	}
 }
 

--- a/update_client.go
+++ b/update_client.go
@@ -257,9 +257,9 @@ func (m *model) handleClientMsg(msg tea.Msg) (tea.Cmd, bool) {
 // updateClientInputs updates form inputs, viewport and history list.
 func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
 	var cmds []tea.Cmd
-	var cmd tea.Cmd
-	m.topics.input, cmd = m.topics.input.Update(msg)
-	cmds = append(cmds, cmd)
+	if cmd := m.topics.UpdateInput(msg); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	if mCmd := m.message.Update(msg); mCmd != nil {
 		cmds = append(cmds, mCmd)
 	}


### PR DESCRIPTION
## Summary
- add `topicsComponent.UpdateInput` helper and expose topic input in `Focusables`
- call `UpdateInput` from client updater instead of touching `topics.input`
- drop direct topic input focusable from the root model

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f367db66c8324bc8de3b0d72a2180