### PR TITLE
refactor: decouple message component from model

### DIFF
--- a/message_api.go
+++ b/message_api.go
@@ -1,0 +1,11 @@
+package emqutiti
+
+// MessageModel defines the dependencies messageComponent requires from the root model.
+type MessageModel interface {
+	Width() int
+	MessageHeight() int
+	FocusedID() string
+	OverlayHelp(view string) string
+}
+
+var _ MessageModel = (*model)(nil)

--- a/message_component.go
+++ b/message_component.go
@@ -17,10 +17,10 @@ func (m *messageState) setPayload(payload string) { m.input.SetValue(payload) }
 // messageComponent implements Component for the message editor.
 type messageComponent struct {
 	*messageState
-	m *model
+	m MessageModel
 }
 
-func newMessageComponent(m *model, ms messageState) *messageComponent {
+func newMessageComponent(m MessageModel, ms messageState) *messageComponent {
 	return &messageComponent{messageState: &ms, m: m}
 }
 
@@ -37,7 +37,7 @@ func (c *messageComponent) Update(msg tea.Msg) tea.Cmd {
 func (c *messageComponent) View() string {
 	msgContent := c.input.View()
 	msgLines := c.input.LineCount()
-	msgHeight := c.m.layout.message.height
+	msgHeight := c.m.MessageHeight()
 	msgSP := -1.0
 	if msgLines > msgHeight {
 		off := c.input.Line() - msgHeight + 1
@@ -52,8 +52,8 @@ func (c *messageComponent) View() string {
 			msgSP = float64(off) / float64(maxOff)
 		}
 	}
-	focused := c.m.ui.focusOrder[c.m.ui.focusIndex] == idMessage
-	return ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", c.m.ui.width-2, msgHeight, ui.ColBlue, focused, msgSP)
+	focused := c.m.FocusedID() == idMessage
+	return ui.LegendBox(msgContent, "Message (Ctrl+S publishes)", c.m.Width()-2, msgHeight, ui.ColBlue, focused, msgSP)
 }
 
 func (c *messageComponent) Focus() tea.Cmd { return c.input.Focus() }

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -133,5 +133,8 @@ func (m *model) PreviousMode() appMode { return m.previousMode() }
 // Width returns the current UI width.
 func (m *model) Width() int { return m.ui.width }
 
+// MessageHeight returns the configured message box height.
+func (m *model) MessageHeight() int { return m.layout.message.height }
+
 // Height returns the current UI height.
 func (m *model) Height() int { return m.ui.height }


### PR DESCRIPTION
## Summary
- add MessageModel interface and MessageHeight accessor
- use MessageModel to render message component

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f4329461883248f21643897bddb0c