### PR TITLE
refactor history component to use model interface

### DIFF
--- a/history_api.go
+++ b/history_api.go
@@ -1,0 +1,16 @@
+package emqutiti
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// historyModel defines the dependencies historyComponent requires from the model.
+type historyModel interface {
+	SetMode(appMode) tea.Cmd
+	PreviousMode() appMode
+	CurrentMode() appMode
+	SetFocus(id string) tea.Cmd
+	Width() int
+	Height() int
+	OverlayHelp(string) string
+}
+
+var _ historyModel = (*model)(nil)

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -130,6 +130,9 @@ func (m *model) SetMode(mode appMode) tea.Cmd { return m.setMode(mode) }
 // PreviousMode exposes previousMode to satisfy the navigator interface.
 func (m *model) PreviousMode() appMode { return m.previousMode() }
 
+// CurrentMode exposes currentMode to satisfy component interfaces.
+func (m *model) CurrentMode() appMode { return m.currentMode() }
+
 // Width returns the current UI width.
 func (m *model) Width() int { return m.ui.width }
 

--- a/update_client.go
+++ b/update_client.go
@@ -82,12 +82,12 @@ func (m *model) ensureTopicVisible() {
 
 // isHistoryFocused reports if the history list has focus.
 func (m *model) isHistoryFocused() bool {
-	return m.ui.focusOrder[m.ui.focusIndex] == idHistory
+	return m.FocusedID() == idHistory
 }
 
 // isTopicsFocused reports if the topics view has focus.
 func (m *model) isTopicsFocused() bool {
-	return m.ui.focusOrder[m.ui.focusIndex] == idTopics
+	return m.FocusedID() == idTopics
 }
 
 // historyScroll forwards scroll events to the history list.
@@ -266,8 +266,10 @@ func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
 	if vpCmd := m.updateViewport(msg); vpCmd != nil {
 		cmds = append(cmds, vpCmd)
 	}
-	if histCmd := m.history.Update(msg); histCmd != nil {
-		cmds = append(cmds, histCmd)
+	if m.FocusedID() == idHistory {
+		if histCmd := m.history.Update(msg); histCmd != nil {
+			cmds = append(cmds, histCmd)
+		}
 	}
 	return cmds
 }
@@ -275,7 +277,7 @@ func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
 // updateViewport updates the main viewport unless history handles the scroll.
 func (m *model) updateViewport(msg tea.Msg) tea.Cmd {
 	skipVP := false
-	if m.ui.focusOrder[m.ui.focusIndex] == idHistory {
+	if m.FocusedID() == idHistory {
 		switch mt := msg.(type) {
 		case tea.KeyMsg:
 			s := mt.String()


### PR DESCRIPTION
## Summary
- introduce a dedicated `historyModel` interface for the history component
- implement `CurrentMode` on the root model and wire the history component through this interface
- forward client input to history only when focused

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f53dd228083248cb752dbbf9c4bd3