### PR TITLE
Refactor confirm component to use navigator and status interfaces

### DIFF
--- a/model_helpers.go
+++ b/model_helpers.go
@@ -27,6 +27,9 @@ func (m *model) FocusedID() string { return m.ui.focusOrder[m.ui.focusIndex] }
 // ListenStatus proxies connection status updates for components.
 func (m *model) ListenStatus() tea.Cmd { return m.connections.ListenStatus() }
 
+// ScrollToFocused ensures the focused element is visible.
+func (m *model) ScrollToFocused() { m.scrollToFocused() }
+
 // ResetElemPos clears cached element positions.
 func (m *model) ResetElemPos() { m.ui.elemPos = map[string]int{} }
 
@@ -43,7 +46,7 @@ func (m *model) StartConfirm(prompt, info string, returnFocus func() tea.Cmd, ac
 
 // startConfirm displays a confirmation dialog and runs the action on accept.
 func (m *model) startConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
-	m.confirm = newConfirmComponent(m, returnFocus, action, cancel)
+	m.confirm = newConfirmComponent(m, m, returnFocus, action, cancel)
 	m.confirm.start(prompt, info)
 	m.components[modeConfirmDelete] = m.confirm
 }

--- a/model_init.go
+++ b/model_init.go
@@ -201,7 +201,7 @@ func initialModel(conns *Connections) (*model, error) {
 	msgComp := newMessageComponent(m, ms)
 	m.message = msgComp
 	m.help = newHelpComponent(m, &m.ui.width, &m.ui.height, &m.ui.elemPos)
-	m.confirm = newConfirmComponent(m, nil, nil, nil)
+	m.confirm = newConfirmComponent(m, m, nil, nil, nil)
 	connComp := newConnectionsComponent(m, m.connectionsAPI())
 	topicsComp := newTopicsComponent(m)
 	m.topics = topicsComp

--- a/navigator.go
+++ b/navigator.go
@@ -8,3 +8,15 @@ type navigator interface {
 	Width() int
 	Height() int
 }
+
+type ConfirmNavigator interface {
+	SetMode(appMode) tea.Cmd
+	PreviousMode() appMode
+	Width() int
+	Height() int
+	ScrollToFocused()
+}
+
+type StatusListener interface {
+	ListenStatus() tea.Cmd
+}

--- a/payloads_component.go
+++ b/payloads_component.go
@@ -8,18 +8,16 @@ import (
 	"github.com/marang/emqutiti/ui"
 )
 
-type statusListener interface{ ListenStatus() tea.Cmd }
-
 type loadPayloadMsg struct{ topic, payload string }
 
 type payloadsComponent struct {
 	m      payloadsModel
-	status statusListener
+	status StatusListener
 	items  []payloadItem
 	list   list.Model
 }
 
-func newPayloadsComponent(m payloadsModel, s statusListener) *payloadsComponent {
+func newPayloadsComponent(m payloadsModel, s StatusListener) *payloadsComponent {
 	l := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	l.DisableQuitKeybindings()
 	l.SetShowTitle(false)


### PR DESCRIPTION
## Summary
- decouple confirmComponent with new `ConfirmNavigator` and `StatusListener` interfaces
- expose `ScrollToFocused` and `ListenStatus` on model; inject interfaces when creating confirm component
- update payloads component and initialization for new interfaces

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f56058e908324a2d11dc1c8b3b0da