### PR TITLE
refactor: snapshot connection state

### DIFF
--- a/client_keys.go
+++ b/client_keys.go
@@ -58,7 +58,7 @@ func (m *model) handleClientKey(msg tea.KeyMsg) tea.Cmd {
 
 // handleQuitKey saves current state and quits the application.
 func (m *model) handleQuitKey() tea.Cmd {
-	m.connections.SaveCurrent(m.topics.items, m.payloads.Items())
+	m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
 	m.traces.savePlannedTraces()
 	return tea.Quit
 }

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -86,7 +86,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 			m.history.Append("", err.Error(), "log", err.Error())
 		}
 		m.connections.RefreshConnectionItems()
-		m.connections.SaveCurrent(m.topics.items, m.payloads.Items())
+		m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
 		m.traces.savePlannedTraces()
 		return m.setMode(modeConnections)
 	case "ctrl+t":

--- a/config_state_test.go
+++ b/config_state_test.go
@@ -76,10 +76,10 @@ func TestSaveLoadState(t *testing.T) {
 	os.Setenv("HOME", dir)
 	defer os.Setenv("HOME", oldHome)
 
-	data := map[string]connectionData{
+	data := map[string]connectionSnapshot{
 		"p1": {
-			Topics:   []topicItem{{title: "foo", subscribed: true}},
-			Payloads: []payloadItem{{topic: "foo", payload: "bar"}},
+			Topics:   []TopicSnapshot{{Title: "foo", Active: true}},
+			Payloads: []PayloadSnapshot{{Topic: "foo", Payload: "bar"}},
 		},
 	}
 	saveState(data)

--- a/connection_profile_store.go
+++ b/connection_profile_store.go
@@ -17,18 +17,7 @@ func saveConfig(profiles []Profile, defaultName string) {
 	cfg := userConfig{
 		DefaultProfileName: defaultName,
 		Profiles:           profiles,
-		Saved:              make(map[string]persistedConn),
-	}
-	for k, v := range saved {
-		var topics []persistedTopic
-		for _, t := range v.Topics {
-			topics = append(topics, persistedTopic{Title: t.title, Active: t.subscribed})
-		}
-		var payloads []persistedPayload
-		for _, p := range v.Payloads {
-			payloads = append(payloads, persistedPayload{Topic: p.topic, Payload: p.payload})
-		}
-		cfg.Saved[k] = persistedConn{Topics: topics, Payloads: payloads}
+		Saved:              saved,
 	}
 	writeConfig(cfg)
 }

--- a/connections_api.go
+++ b/connections_api.go
@@ -133,9 +133,9 @@ func (c *connectionsModel) HandleConnectResult(msg connectResult) {
 		}
 		c.history.list.SetItems(items)
 	}
-	topics, payloads := c.connections.RestoreState(msg.profile.Name)
-	c.topics.items = topics
-	c.payloads.SetItems(payloads)
+	ts, ps := c.connections.RestoreState(msg.profile.Name)
+	c.topics.SetSnapshot(ts)
+	c.payloads.SetSnapshot(ps)
 	c.topics.SortTopics()
 	c.topics.RebuildActiveTopicList()
 	c.SubscribeActiveTopics()

--- a/connections_component.go
+++ b/connections_component.go
@@ -26,12 +26,6 @@ func (c connectionItem) Description() string {
 	return c.status
 }
 
-// connectionData stores topics and payloads for a connection.
-type connectionData struct {
-	Topics   []topicItem
-	Payloads []payloadItem
-}
-
 // connectionsState holds connection related state shared across components.
 type connectionsState struct {
 	connection  string
@@ -40,7 +34,7 @@ type connectionsState struct {
 	form        *connectionForm
 	deleteIndex int
 	statusChan  chan string
-	saved       map[string]connectionData
+	saved       map[string]connectionSnapshot
 }
 
 // ConnectionStatusManager exposes methods to update connection status information.
@@ -98,20 +92,20 @@ func (c *connectionsState) RefreshConnectionItems() {
 }
 
 // SaveCurrent persists topics and payloads for the active connection.
-func (c *connectionsState) SaveCurrent(topics []topicItem, payloads []payloadItem) {
+func (c *connectionsState) SaveCurrent(topics []TopicSnapshot, payloads []PayloadSnapshot) {
 	if c.active == "" {
 		return
 	}
-	c.saved[c.active] = connectionData{Topics: topics, Payloads: payloads}
+	c.saved[c.active] = connectionSnapshot{Topics: topics, Payloads: payloads}
 	saveState(c.saved)
 }
 
 // RestoreState returns saved topics and payloads for the named connection.
-func (c *connectionsState) RestoreState(name string) ([]topicItem, []payloadItem) {
+func (c *connectionsState) RestoreState(name string) ([]TopicSnapshot, []PayloadSnapshot) {
 	if data, ok := c.saved[name]; ok {
 		return data.Topics, data.Payloads
 	}
-	return []topicItem{}, []payloadItem{}
+	return []TopicSnapshot{}, []PayloadSnapshot{}
 }
 
 // connectionsComponent implements the Component interface for managing brokers.

--- a/payloads_api.go
+++ b/payloads_api.go
@@ -1,5 +1,15 @@
 package emqutiti
 
+// PayloadsAPI exposes payload management behavior to the rest of the application.
+type PayloadsAPI interface {
+	Add(topic, payload string)
+	Items() []payloadItem
+	SetItems([]payloadItem)
+	Snapshot() []PayloadSnapshot
+	SetSnapshot([]PayloadSnapshot)
+	Clear()
+}
+
 // payloadsModel defines the dependencies payloadsComponent requires from the model.
 type payloadsModel interface {
 	navigator
@@ -10,3 +20,4 @@ type payloadsModel interface {
 }
 
 var _ payloadsModel = (*model)(nil)
+var _ PayloadsAPI = (*payloadsComponent)(nil)

--- a/payloads_snapshot.go
+++ b/payloads_snapshot.go
@@ -1,0 +1,25 @@
+package emqutiti
+
+// PayloadSnapshot represents a stored payload for persistence.
+type PayloadSnapshot struct {
+	Topic   string `toml:"topic"`
+	Payload string `toml:"payload"`
+}
+
+// Snapshot returns a serializable copy of the current payloads.
+func (p *payloadsComponent) Snapshot() []PayloadSnapshot {
+	out := make([]PayloadSnapshot, len(p.items))
+	for i, item := range p.items {
+		out[i] = PayloadSnapshot{Topic: item.topic, Payload: item.payload}
+	}
+	return out
+}
+
+// SetSnapshot replaces the current payloads with the provided snapshot.
+func (p *payloadsComponent) SetSnapshot(ps []PayloadSnapshot) {
+	items := make([]payloadItem, len(ps))
+	for i, s := range ps {
+		items[i] = payloadItem{topic: s.Topic, payload: s.Payload}
+	}
+	p.SetItems(items)
+}

--- a/topics_api.go
+++ b/topics_api.go
@@ -19,6 +19,8 @@ type TopicsAPI interface {
 	SetActivePane(idx int)
 	SetSelected(int)
 	Selected() int
+	Snapshot() []TopicSnapshot
+	SetSnapshot([]TopicSnapshot)
 }
 
 // topicsModel defines the dependencies topicsComponent requires from the model.

--- a/topics_snapshot.go
+++ b/topics_snapshot.go
@@ -1,0 +1,24 @@
+package emqutiti
+
+// TopicSnapshot represents a topic and its subscription state for persistence.
+type TopicSnapshot struct {
+	Title  string `toml:"title"`
+	Active bool   `toml:"active"`
+}
+
+// Snapshot returns a serializable copy of the current topics.
+func (c *topicsComponent) Snapshot() []TopicSnapshot {
+	out := make([]TopicSnapshot, len(c.items))
+	for i, t := range c.items {
+		out[i] = TopicSnapshot{Title: t.title, Active: t.subscribed}
+	}
+	return out
+}
+
+// SetSnapshot replaces the current topics with the provided snapshot.
+func (c *topicsComponent) SetSnapshot(ts []TopicSnapshot) {
+	c.items = make([]topicItem, len(ts))
+	for i, t := range ts {
+		c.items[i] = topicItem{title: t.Title, subscribed: t.Active}
+	}
+}


### PR DESCRIPTION
## Summary
- decouple connection persistence using topic and payload snapshots
- wire snapshot save/restore into connection lifecycle

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f58d7722083249bce0ad648ca23c9