### PR TITLE
Export history helpers

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -78,7 +78,7 @@ func (m *model) handleClearFilterKey() tea.Cmd {
 	} else {
 		msgs = m.history.Store().Search(false, nil, time.Time{}, time.Time{}, "")
 	}
-	hitems, items := messagesToHistoryItems(msgs)
+	hitems, items := history.MessagesToItems(msgs)
 	m.history.SetItems(hitems)
 	m.history.List().SetItems(items)
 	return nil

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -21,7 +21,7 @@ func (m *model) handleToggleArchiveKey() tea.Cmd {
 		} else {
 			msgs = m.history.Store().Search(false, nil, time.Time{}, time.Time{}, "")
 		}
-		hitems, items := messagesToHistoryItems(msgs)
+		hitems, items := history.MessagesToItems(msgs)
 		m.history.SetItems(hitems)
 		m.history.List().SetItems(items)
 		if len(items) > 0 {

--- a/history/api.go
+++ b/history/api.go
@@ -60,7 +60,7 @@ func NewComponent(m Model, st Store) *Component {
 	if st != nil {
 		msgs := st.Search(false, nil, time.Time{}, time.Time{}, "")
 		var items []list.Item
-		hs.items, items = messagesToHistoryItems(msgs)
+		hs.items, items = MessagesToItems(msgs)
 		hs.list.SetItems(items)
 	}
 	return &Component{historyState: &hs, m: m}

--- a/history/history_component.go
+++ b/history/history_component.go
@@ -89,7 +89,7 @@ func (h *Component) UpdateFilter(msg tea.Msg) tea.Cmd {
 				msgs = h.store.Search(false, topics, start, end, payload)
 			}
 			var items []list.Item
-			h.items, items = messagesToHistoryItems(msgs)
+			h.items, items = MessagesToItems(msgs)
 			h.list.SetItems(items)
 			h.list.FilterInput.SetValue("")
 			h.list.SetFilterState(list.Unfiltered)
@@ -146,7 +146,7 @@ func (h *Component) Append(topic, payload, kind, logText string) {
 	if !h.showArchived {
 		if h.filterQuery != "" {
 			var items []list.Item
-			h.items, items = applyHistoryFilter(h.filterQuery, h.store, h.showArchived)
+			h.items, items = ApplyFilter(h.filterQuery, h.store, h.showArchived)
 			h.list.SetItems(items)
 			h.list.Select(len(items) - 1)
 		} else {

--- a/history/history_util.go
+++ b/history/history_util.go
@@ -2,9 +2,9 @@ package history
 
 import "github.com/charmbracelet/bubbles/list"
 
-// messagesToHistoryItems converts a slice of messages into history items
-// and a matching slice of list items for use with the history list.
-func messagesToHistoryItems(msgs []Message) ([]Item, []list.Item) {
+// MessagesToItems converts a slice of messages into history items and a
+// matching slice of list items for use with the history list.
+func MessagesToItems(msgs []Message) ([]Item, []list.Item) {
 	hitems := make([]Item, len(msgs))
 	litems := make([]list.Item, len(msgs))
 	for i, m := range msgs {
@@ -21,8 +21,9 @@ func messagesToHistoryItems(msgs []Message) ([]Item, []list.Item) {
 	return hitems, litems
 }
 
-// applyHistoryFilter parses the query and retrieves matching messages from the store.
-func applyHistoryFilter(q string, store Store, archived bool) ([]Item, []list.Item) {
+// ApplyFilter parses the query and retrieves matching messages from the
+// store.
+func ApplyFilter(q string, store Store, archived bool) ([]Item, []list.Item) {
 	if store == nil {
 		return nil, nil
 	}
@@ -33,5 +34,5 @@ func applyHistoryFilter(q string, store Store, archived bool) ([]Item, []list.It
 	} else {
 		msgs = store.Search(false, topics, start, end, payload)
 	}
-	return messagesToHistoryItems(msgs)
+	return MessagesToItems(msgs)
 }

--- a/history/history_util_test.go
+++ b/history/history_util_test.go
@@ -5,13 +5,13 @@ import (
 	"time"
 )
 
-// TestMessagesToHistoryItems verifies conversion from Message slices to history items.
-func TestMessagesToHistoryItems(t *testing.T) {
+// TestMessagesToItems verifies conversion from Message slices to history items.
+func TestMessagesToItems(t *testing.T) {
 	msgs := []Message{
 		{Timestamp: time.Unix(0, 1), Topic: "t1", Payload: "p1", Kind: "pub", Archived: false},
 		{Timestamp: time.Unix(0, 2), Topic: "t2", Payload: "p2", Kind: "sub", Archived: true},
 	}
-	hitems, litems := messagesToHistoryItems(msgs)
+	hitems, litems := MessagesToItems(msgs)
 	if len(hitems) != len(msgs) {
 		t.Fatalf("history items len %d want %d", len(hitems), len(msgs))
 	}

--- a/model_history.go
+++ b/model_history.go
@@ -260,39 +260,6 @@ func (f historyFilterForm) query() string {
 	return strings.Join(parts, " ")
 }
 
-// messagesToHistoryItems converts messages into history items and list items.
-func messagesToHistoryItems(msgs []history.Message) ([]history.Item, []list.Item) {
-	hitems := make([]history.Item, len(msgs))
-	litems := make([]list.Item, len(msgs))
-	for i, m := range msgs {
-		hi := history.Item{
-			Timestamp: m.Timestamp,
-			Topic:     m.Topic,
-			Payload:   m.Payload,
-			Kind:      m.Kind,
-			Archived:  m.Archived,
-		}
-		hitems[i] = hi
-		litems[i] = hi
-	}
-	return hitems, litems
-}
-
-// applyHistoryFilter parses the query and retrieves matching messages from the store.
-func applyHistoryFilter(q string, store history.Store, archived bool) ([]history.Item, []list.Item) {
-	if store == nil {
-		return nil, nil
-	}
-	topics, start, end, payload := parseHistoryQuery(q)
-	var msgs []history.Message
-	if archived {
-		msgs = store.Search(true, topics, start, end, payload)
-	} else {
-		msgs = store.Search(false, topics, start, end, payload)
-	}
-	return messagesToHistoryItems(msgs)
-}
-
 // parseHistoryQuery interprets a filter string.
 func parseHistoryQuery(q string) (topics []string, start, end time.Time, payload string) {
 	var payloadParts []string

--- a/model_init.go
+++ b/model_init.go
@@ -74,7 +74,7 @@ func initHistory() (historyState, historyDelegate) {
 		hs.store = idx
 		msgs := idx.Search(false, nil, time.Time{}, time.Time{}, "")
 		var items []list.Item
-		hs.items, items = messagesToHistoryItems(msgs)
+		hs.items, items = history.MessagesToItems(msgs)
 		hs.list.SetItems(items)
 	}
 	return hs, hDel

--- a/update_client.go
+++ b/update_client.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/history"
 )
 
 // handleStatusMessage processes broker status updates.
@@ -194,12 +196,12 @@ func (m *model) updateViewport(msg tea.Msg) tea.Cmd {
 func (m *model) filterHistoryList() {
 	if st := m.history.List().FilterState(); st == list.Filtering || st == list.FilterApplied {
 		q := m.history.List().FilterInput.Value()
-		hitems, litems := applyHistoryFilter(q, m.history.Store(), m.history.ShowArchived())
+		hitems, litems := history.ApplyFilter(q, m.history.Store(), m.history.ShowArchived())
 		m.history.SetItems(hitems)
 		m.history.SetFilterQuery(q)
 		m.history.List().SetItems(litems)
 	} else if m.history.FilterQuery() != "" {
-		hitems, litems := applyHistoryFilter(m.history.FilterQuery(), m.history.Store(), m.history.ShowArchived())
+		hitems, litems := history.ApplyFilter(m.history.FilterQuery(), m.history.Store(), m.history.ShowArchived())
 		m.history.SetItems(hitems)
 		m.history.List().SetItems(litems)
 	} else {


### PR DESCRIPTION
## Summary
- export MessagesToItems and ApplyFilter helpers from history
- remove duplicate history helper implementations in root and switch callers to new API

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688f9bb88c2c8324910307d5ad6ea2f9