### PR TITLE
Add client key handler API

### DIFF
--- a/clientkeys/api.go
+++ b/clientkeys/api.go
@@ -1,0 +1,17 @@
+package clientkeys
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// Handler processes keyboard input in client mode.
+type Handler interface {
+	// HandleClientKey reacts to a key message and optionally returns a Tea command.
+	HandleClientKey(msg tea.KeyMsg) tea.Cmd
+}
+
+// HandleClientKey dispatches a key message to the provided handler.
+func HandleClientKey(h Handler, msg tea.KeyMsg) tea.Cmd {
+	if h == nil {
+		return nil
+	}
+	return h.HandleClientKey(msg)
+}


### PR DESCRIPTION
## Summary
- introduce client key handler interface and helper

## Testing
- `go vet ./...` *(fails: m.handleClientKey undefined)*
- `go test ./...` *(fails: undefined: model; m.handleClientKey undefined)*

------
https://chatgpt.com/codex/tasks/task_e_688fae2eb3f883248c429a579033449e