### PR TITLE
refactor: use clientkeys API

### DIFF
--- a/model.go
+++ b/model.go
@@ -4,6 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/connections"
 	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/importer"
@@ -11,6 +12,7 @@ import (
 
 // reference history package to avoid unused import warning
 var _ = history.ID
+var _ clientkeys.Handler = (*model)(nil)
 
 // Component defines a screen or feature that can participate in the Tea update
 // and view cycle. Implementations handle their own initialization, state

--- a/model_init.go
+++ b/model_init.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	_ "github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/importer"
 	"github.com/marang/emqutiti/ui"
 

--- a/update_client.go
+++ b/update_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -142,7 +143,7 @@ func (m *model) handleClientMsg(msg tea.Msg) (tea.Cmd, bool) {
 	case MQTTMessage:
 		return m.handleMQTTMessage(t), true
 	case tea.KeyMsg:
-		return m.handleClientKey(t), false
+		return clientkeys.HandleClientKey(m, t), false
 	case tea.MouseMsg:
 		return m.handleClientMouse(t), false
 	}

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -20,7 +21,7 @@ func TestHandleClientKeyCopySelected(t *testing.T) {
 	m.history.List().SetItems([]list.Item{hi})
 	m.history.List().Select(0)
 
-	m.handleClientKey(tea.KeyMsg{Type: tea.KeyCtrlC})
+	clientkeys.HandleClientKey(m, tea.KeyMsg{Type: tea.KeyCtrlC})
 
 	if len(m.history.Items()) != 2 {
 		t.Fatalf("expected error appended to history, got %d items", len(m.history.Items()))
@@ -44,7 +45,7 @@ func TestHandleClientKeyDisconnect(t *testing.T) {
 	m.connections.SetConnected("test")
 	m.connections.Manager.Errors["test"] = "boom"
 
-	m.handleClientKey(tea.KeyMsg{Type: tea.KeyCtrlX})
+	clientkeys.HandleClientKey(m, tea.KeyMsg{Type: tea.KeyCtrlX})
 
 	if m.mqttClient != nil {
 		t.Fatalf("expected mqttClient nil after disconnect")
@@ -67,7 +68,7 @@ func TestHandleClientKeyFilterInitiation(t *testing.T) {
 	m.focus.Set(idx)
 	m.ui.focusIndex = idx
 
-	m.handleClientKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
+	clientkeys.HandleClientKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 
 	if m.ui.modeStack[0] != modeHistoryFilter {
 		t.Fatalf("expected modeHistoryFilter, got %v", m.ui.modeStack[0])


### PR DESCRIPTION
## Summary
- wire client key handling through new clientkeys package
- adapt tests to clientkeys API

## Testing
- `go vet ./...` *(fails: undefined: model)*
- `go test ./...` *(fails: undefined: model)*

------
https://chatgpt.com/codex/tasks/task_e_688faff6b77c832494b592ad8b23a186