### PR TITLE
refactor: extract confirm component

### DIFF
--- a/confirm/api.go
+++ b/confirm/api.go
@@ -1,0 +1,22 @@
+package confirm
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// API exposes confirmation dialogs to components.
+type API interface {
+	StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func())
+}
+
+// Navigator defines navigation helpers required by the confirm component.
+type Navigator interface {
+	SetConfirmMode() tea.Cmd
+	SetPreviousMode() tea.Cmd
+	Width() int
+	Height() int
+	ScrollToFocused()
+}
+
+// StatusListener provides status updates for components.
+type StatusListener interface {
+	ListenStatus() tea.Cmd
+}

--- a/confirm/component.go
+++ b/confirm/component.go
@@ -1,4 +1,4 @@
-package emqutiti
+package confirm
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
@@ -7,8 +7,8 @@ import (
 	"github.com/marang/emqutiti/ui"
 )
 
-type confirmComponent struct {
-	nav    ConfirmNavigator
+type Component struct {
+	nav    Navigator
 	status StatusListener
 
 	prompt      string
@@ -19,19 +19,19 @@ type confirmComponent struct {
 	focused     bool
 }
 
-func newConfirmComponent(nav ConfirmNavigator, status StatusListener, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) *confirmComponent {
-	return &confirmComponent{nav: nav, status: status, returnFocus: returnFocus, action: action, cancel: cancel}
+func NewComponent(nav Navigator, status StatusListener, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) *Component {
+	return &Component{nav: nav, status: status, returnFocus: returnFocus, action: action, cancel: cancel}
 }
 
-func (c *confirmComponent) Init() tea.Cmd { return nil }
+func (c *Component) Init() tea.Cmd { return nil }
 
-func (c *confirmComponent) start(prompt, info string) {
+func (c *Component) Start(prompt, info string) {
 	c.prompt = prompt
 	c.info = info
-	_ = c.nav.SetMode(modeConfirmDelete)
+	_ = c.nav.SetConfirmMode()
 }
 
-func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
+func (c *Component) Update(msg tea.Msg) tea.Cmd {
 	switch t := msg.(type) {
 	case tea.KeyMsg:
 		switch t.String() {
@@ -46,7 +46,7 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 			if c.cancel != nil {
 				c.cancel = nil
 			}
-			cmd := c.nav.SetMode(c.nav.PreviousMode())
+			cmd := c.nav.SetPreviousMode()
 			cmds := []tea.Cmd{cmd, c.status.ListenStatus()}
 			if acmd != nil {
 				cmds = append(cmds, acmd)
@@ -63,7 +63,7 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 				c.cancel()
 				c.cancel = nil
 			}
-			cmd := c.nav.SetMode(c.nav.PreviousMode())
+			cmd := c.nav.SetPreviousMode()
 			cmds := []tea.Cmd{cmd, c.status.ListenStatus()}
 			if c.returnFocus != nil {
 				cmds = append(cmds, c.returnFocus())
@@ -77,7 +77,7 @@ func (c *confirmComponent) Update(msg tea.Msg) tea.Cmd {
 	return c.status.ListenStatus()
 }
 
-func (c *confirmComponent) View() string {
+func (c *Component) View() string {
 	content := c.prompt
 	if c.info != "" {
 		content = lipgloss.JoinVertical(lipgloss.Left, c.prompt, c.info)
@@ -87,14 +87,11 @@ func (c *confirmComponent) View() string {
 	return lipgloss.Place(c.nav.Width(), c.nav.Height(), lipgloss.Center, lipgloss.Center, box)
 }
 
-func (c *confirmComponent) Focus() tea.Cmd {
+func (c *Component) Focus() tea.Cmd {
 	c.focused = true
 	return nil
 }
 
-func (c *confirmComponent) Blur() { c.focused = false }
+func (c *Component) Blur() { c.focused = false }
 
-func (c *confirmComponent) Focused() bool { return c.focused }
-
-// Focusables exposes focusable elements for the confirm component.
-func (c *confirmComponent) Focusables() map[string]Focusable { return map[string]Focusable{} }
+func (c *Component) Focused() bool { return c.focused }

--- a/model.go
+++ b/model.go
@@ -5,6 +5,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/marang/emqutiti/clientkeys"
+	"github.com/marang/emqutiti/confirm"
 	"github.com/marang/emqutiti/connections"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/history"
@@ -111,7 +112,7 @@ type model struct {
 
 	ui uiState
 
-	confirm *confirmComponent
+	confirm *confirm.Component
 
 	layout layoutConfig
 

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -4,6 +4,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"time"
 
+	"github.com/marang/emqutiti/confirm"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -49,8 +50,8 @@ func (m *model) StartConfirm(prompt, info string, returnFocus func() tea.Cmd, ac
 
 // startConfirm displays a confirmation dialog and runs the action on accept.
 func (m *model) startConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
-	m.confirm = newConfirmComponent(m, m, returnFocus, action, cancel)
-	m.confirm.start(prompt, info)
+	m.confirm = confirm.NewComponent(m, m, returnFocus, action, cancel)
+	m.confirm.Start(prompt, info)
 	m.components[modeConfirmDelete] = m.confirm
 }
 
@@ -135,6 +136,12 @@ func (m *model) SetMode(mode appMode) tea.Cmd { return m.setMode(mode) }
 
 // PreviousMode exposes previousMode to satisfy the navigator interface.
 func (m *model) PreviousMode() appMode { return m.previousMode() }
+
+// SetConfirmMode switches to the confirmation screen.
+func (m *model) SetConfirmMode() tea.Cmd { return m.setMode(modeConfirmDelete) }
+
+// SetPreviousMode returns to the prior screen.
+func (m *model) SetPreviousMode() tea.Cmd { return m.setMode(m.previousMode()) }
 
 // CurrentMode exposes currentMode to satisfy component interfaces.
 func (m *model) CurrentMode() appMode { return m.currentMode() }

--- a/model_init.go
+++ b/model_init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	_ "github.com/marang/emqutiti/clientkeys"
+	"github.com/marang/emqutiti/confirm"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/importer"
 	"github.com/marang/emqutiti/message"
@@ -122,7 +123,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	msgComp := message.NewComponent(m, ms)
 	m.message = msgComp
 	m.help = help.New(navAdapter{m}, &m.ui.width, &m.ui.height, &m.ui.elemPos)
-	m.confirm = newConfirmComponent(m, m, nil, nil, nil)
+	m.confirm = confirm.NewComponent(m, m, nil, nil, nil)
 	connComp := connections.NewComponent(navAdapter{m}, m.connectionsAPI())
 	topicsComp := topics.New(m)
 	m.topics = topicsComp
@@ -131,7 +132,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.traces = tracesComp
 
 	// Collect focusable elements from model and components.
-	providers := []FocusableSet{m, topicsComp, msgComp, m.payloads, tracesComp, m.help, m.confirm}
+	providers := []FocusableSet{m, topicsComp, msgComp, m.payloads, tracesComp, m.help}
 	m.focusables = map[string]Focusable{}
 	for _, p := range providers {
 		for id, f := range p.Focusables() {

--- a/navigator.go
+++ b/navigator.go
@@ -8,15 +8,3 @@ type navigator interface {
 	Width() int
 	Height() int
 }
-
-type ConfirmNavigator interface {
-	SetMode(appMode) tea.Cmd
-	PreviousMode() appMode
-	Width() int
-	Height() int
-	ScrollToFocused()
-}
-
-type StatusListener interface {
-	ListenStatus() tea.Cmd
-}

--- a/topics/api.go
+++ b/topics/api.go
@@ -3,6 +3,8 @@ package topics
 import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/confirm"
 )
 
 // API exposes topic management behavior to the rest of the application.
@@ -25,10 +27,10 @@ type API interface {
 
 // Model defines the dependencies Component requires from the host application.
 type Model interface {
+	confirm.API
 	ShowClient() tea.Cmd
 	SetFocus(id string) tea.Cmd
 	FocusedID() string
-	StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func())
 	ResetElemPos()
 	SetElemPos(id string, pos int)
 	OverlayHelp(view string) string

--- a/traces/api.go
+++ b/traces/api.go
@@ -2,6 +2,7 @@ package traces
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marang/emqutiti/confirm"
 	"github.com/marang/emqutiti/connections"
 )
 
@@ -10,6 +11,7 @@ const IDList = "trace-list"
 
 // API defines interactions required by the traces component from the host model.
 type API interface {
+	confirm.API
 	SetModeClient() tea.Cmd
 	SetModeTracer() tea.Cmd
 	SetModeEditTrace() tea.Cmd
@@ -19,7 +21,6 @@ type API interface {
 	ResetElemPos()
 	SetElemPos(id string, pos int)
 	OverlayHelp(view string) string
-	StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func())
 	Profiles() []connections.Profile
 	ActiveConnection() string
 	SubscribedTopics() []string


### PR DESCRIPTION
## Summary
- move confirmation dialog into new `confirm` package
- expose `confirm.API` and navigation helpers
- update model, topics, and traces to use the new component

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688fd879a49c8324a5ac3eef822fd20c