### PR TITLE
refactor: centralize focus helpers

### DIFF
--- a/focus/focusmap.go
+++ b/focus/focusmap.go
@@ -1,42 +1,45 @@
-package emqutiti
+package focus
 
-import (
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/marang/emqutiti/topics"
-)
+import tea "github.com/charmbracelet/bubbletea"
 
 // Focusable represents a UI element that can gain or lose focus.
-type Focusable = topics.Focusable
+type Focusable interface {
+	Focus()
+	Blur()
+	IsFocused() bool
+	View() string
+}
 
 // FocusableSet exposes a collection of focusable elements.
 type FocusableSet interface {
 	Focusables() map[string]Focusable
 }
 
-type teaFocusable interface {
+// TeaFocusable adapts Bubble Tea models to Focusable.
+type TeaFocusable interface {
 	Focus() tea.Cmd
 	Blur()
 	Focused() bool
 	View() string
 }
 
-// adapt converts a Bubble Tea focusable model into the Focusable interface.
-func adapt(f teaFocusable) Focusable { return focusAdapter{f} }
+// Adapt converts a Bubble Tea focusable model into the Focusable interface.
+func Adapt(f TeaFocusable) Focusable { return focusAdapter{f} }
 
-type focusAdapter struct{ f teaFocusable }
+type focusAdapter struct{ f TeaFocusable }
 
 func (a focusAdapter) Focus()          { _ = a.f.Focus() }
 func (a focusAdapter) Blur()           { a.f.Blur() }
 func (a focusAdapter) IsFocused() bool { return a.f.Focused() }
 func (a focusAdapter) View() string    { return a.f.View() }
 
-// nullFocusable is a no-op focusable used for non-interactive areas.
-type nullFocusable struct{ focused bool }
+// NullFocusable is a no-op focusable used for non-interactive areas.
+type NullFocusable struct{ focused bool }
 
-func (n *nullFocusable) Focus()          { n.focused = true }
-func (n *nullFocusable) Blur()           { n.focused = false }
-func (n *nullFocusable) IsFocused() bool { return n.focused }
-func (n *nullFocusable) View() string    { return "" }
+func (n *NullFocusable) Focus()          { n.focused = true }
+func (n *NullFocusable) Blur()           { n.focused = false }
+func (n *NullFocusable) IsFocused() bool { return n.focused }
+func (n *NullFocusable) View() string    { return "" }
 
 // FocusMap manages focus among a set of focusable elements.
 type FocusMap struct {

--- a/help/api.go
+++ b/help/api.go
@@ -2,7 +2,7 @@ package help
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/marang/emqutiti/topics"
+	"github.com/marang/emqutiti/focus"
 )
 
 // ID is the focus identifier for the help component.
@@ -16,5 +16,5 @@ type Navigator interface {
 	Height() int
 }
 
-// Focusable re-exports the topics.Focusable interface.
-type Focusable = topics.Focusable
+// Focusable re-exports the focus.Focusable interface.
+type Focusable = focus.Focusable

--- a/help/component.go
+++ b/help/component.go
@@ -5,7 +5,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/marang/emqutiti/topics"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -80,23 +80,6 @@ func (h *Component) Blur() { h.focused = false }
 func (h *Component) Focused() bool { return h.focused }
 
 // Focusables exposes focusable elements for the help component.
-func (h *Component) Focusables() map[string]topics.Focusable {
-	return map[string]topics.Focusable{ID: adapt(h)}
+func (h *Component) Focusables() map[string]focus.Focusable {
+	return map[string]focus.Focusable{ID: focus.Adapt(h)}
 }
-
-// teaFocusable adapts the component for use with FocusMap.
-type teaFocusable interface {
-	Focus() tea.Cmd
-	Blur()
-	Focused() bool
-	View() string
-}
-
-func adapt(f teaFocusable) topics.Focusable { return focusAdapter{f} }
-
-type focusAdapter struct{ f teaFocusable }
-
-func (a focusAdapter) Focus()          { _ = a.f.Focus() }
-func (a focusAdapter) Blur()           { a.f.Blur() }
-func (a focusAdapter) IsFocused() bool { return a.f.Focused() }
-func (a focusAdapter) View() string    { return a.f.View() }

--- a/message/component.go
+++ b/message/component.go
@@ -4,7 +4,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/marang/emqutiti/topics"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -67,24 +67,6 @@ func (c *Component) Input() *textarea.Model { return &c.TA }
 func (c *Component) SetPayload(payload string) { c.TA.SetValue(payload) }
 
 // Focusables exposes focusable elements for the message component.
-func (c *Component) Focusables() map[string]topics.Focusable {
-	return map[string]topics.Focusable{ID: adapt(&c.TA)}
+func (c *Component) Focusables() map[string]focus.Focusable {
+	return map[string]focus.Focusable{ID: focus.Adapt(&c.TA)}
 }
-
-// --- focus adapter helpers ---
-
-type teaFocusable interface {
-	Focus() tea.Cmd
-	Blur()
-	Focused() bool
-	View() string
-}
-
-func adapt(f teaFocusable) topics.Focusable { return focusAdapter{f} }
-
-type focusAdapter struct{ f teaFocusable }
-
-func (a focusAdapter) Focus()          { _ = a.f.Focus() }
-func (a focusAdapter) Blur()           { a.f.Blur() }
-func (a focusAdapter) IsFocused() bool { return a.f.Focused() }
-func (a focusAdapter) View() string    { return a.f.View() }

--- a/model.go
+++ b/model.go
@@ -7,6 +7,7 @@ import (
 	"github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/confirm"
 	"github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/importer"
@@ -121,15 +122,15 @@ type model struct {
 	// logic which the model delegates to at runtime.
 	components map[appMode]Component
 
-	focusables map[string]Focusable
-	focus      *FocusMap
+	focusables map[string]focus.Focusable
+	focus      *focus.FocusMap
 }
 
 // Focusables returns the base focusable elements managed by the model.
-func (m *model) Focusables() map[string]Focusable {
-	return map[string]Focusable{
-		idTopics:      &nullFocusable{},
-		idHistory:     &nullFocusable{},
-		traces.IDList: &nullFocusable{},
+func (m *model) Focusables() map[string]focus.Focusable {
+	return map[string]focus.Focusable{
+		idTopics:      &focus.NullFocusable{},
+		idHistory:     &focus.NullFocusable{},
+		traces.IDList: &focus.NullFocusable{},
 	}
 }

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/marang/emqutiti/confirm"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -80,8 +81,10 @@ func (m *model) startHistoryFilter() tea.Cmd {
 
 // setMode updates the current mode and focus order.
 func (m *model) setMode(mode appMode) tea.Cmd {
-	if m.focus != nil && len(m.focus.items) > 0 {
-		m.focus.items[m.focus.focusIndex].Blur()
+	if m.focus != nil && len(m.ui.focusOrder) > m.ui.focusIndex {
+		if f, ok := m.focusables[m.ui.focusOrder[m.ui.focusIndex]]; ok {
+			f.Blur()
+		}
 	}
 	// push mode to stack
 	if len(m.ui.modeStack) == 0 || m.ui.modeStack[0] != mode {
@@ -105,11 +108,11 @@ func (m *model) setMode(mode appMode) tea.Cmd {
 		order = []string{idHelp}
 	}
 	m.ui.focusOrder = append([]string(nil), order...)
-	items := make([]Focusable, len(order))
+	items := make([]focus.Focusable, len(order))
 	for i, id := range order {
 		items[i] = m.focusables[id]
 	}
-	m.focus = NewFocusMap(items)
+	m.focus = focus.NewFocusMap(items)
 	m.ui.focusIndex = m.focus.Index()
 	m.help.Blur()
 	return nil

--- a/model_init.go
+++ b/model_init.go
@@ -11,6 +11,7 @@ import (
 
 	_ "github.com/marang/emqutiti/clientkeys"
 	"github.com/marang/emqutiti/confirm"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/importer"
 	"github.com/marang/emqutiti/message"
@@ -132,18 +133,18 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.traces = tracesComp
 
 	// Collect focusable elements from model and components.
-	providers := []FocusableSet{m, topicsComp, msgComp, m.payloads, tracesComp, m.help}
-	m.focusables = map[string]Focusable{}
+	providers := []focus.FocusableSet{m, topicsComp, msgComp, m.payloads, tracesComp, m.help}
+	m.focusables = map[string]focus.Focusable{}
 	for _, p := range providers {
 		for id, f := range p.Focusables() {
 			m.focusables[id] = f
 		}
 	}
-	fitems := make([]Focusable, len(order))
+	fitems := make([]focus.Focusable, len(order))
 	for i, id := range order {
 		fitems[i] = m.focusables[id]
 	}
-	m.focus = NewFocusMap(fitems)
+	m.focus = focus.NewFocusMap(fitems)
 	traceDel.T = m.traces
 	m.traces.ViewList().SetDelegate(traceDel)
 	// Register mode components so that view and update logic can be

--- a/payloads/payloads_component.go
+++ b/payloads/payloads_component.go
@@ -5,7 +5,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/marang/emqutiti/topics"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -85,8 +85,8 @@ func (p *Component) Focus() tea.Cmd { return nil }
 func (p *Component) Blur() {}
 
 // Focusables exposes focusable elements for the payloads component.
-func (p *Component) Focusables() map[string]topics.Focusable {
-	return map[string]topics.Focusable{IDList: &nullFocusable{}}
+func (p *Component) Focusables() map[string]focus.Focusable {
+	return map[string]focus.Focusable{IDList: &nullFocusable{}}
 }
 
 func (p *Component) Add(topic, payload string) {

--- a/topics/component.go
+++ b/topics/component.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -180,11 +181,11 @@ func (c *Component) UpdateInput(msg tea.Msg) tea.Cmd {
 }
 
 // Focusables exposes focusable elements for the topics component.
-func (c *Component) Focusables() map[string]Focusable {
-	return map[string]Focusable{
+func (c *Component) Focusables() map[string]focus.Focusable {
+	return map[string]focus.Focusable{
 		idTopicsEnabled:  &c.panes.subscribed,
 		idTopicsDisabled: &c.panes.unsubscribed,
-		idTopic:          adapt(&c.Input),
+		idTopic:          focus.Adapt(&c.Input),
 	}
 }
 

--- a/topics/types.go
+++ b/topics/types.go
@@ -1,30 +1,5 @@
 package topics
 
-import tea "github.com/charmbracelet/bubbletea"
-
-type Focusable interface {
-	Focus()
-	Blur()
-	IsFocused() bool
-	View() string
-}
-
-type teaFocusable interface {
-	Focus() tea.Cmd
-	Blur()
-	Focused() bool
-	View() string
-}
-
-func adapt(f teaFocusable) Focusable { return focusAdapter{f} }
-
-type focusAdapter struct{ f teaFocusable }
-
-func (a focusAdapter) Focus()          { _ = a.f.Focus() }
-func (a focusAdapter) Blur()           { a.f.Blur() }
-func (a focusAdapter) IsFocused() bool { return a.f.Focused() }
-func (a focusAdapter) View() string    { return a.f.View() }
-
 const (
 	idTopicsEnabled  = "topics-enabled"
 	idTopicsDisabled = "topics-disabled"

--- a/traces/component.go
+++ b/traces/component.go
@@ -14,7 +14,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
 
-	"github.com/marang/emqutiti/topics"
+	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -101,7 +101,7 @@ func (t *Component) Focus() tea.Cmd { return nil }
 func (t *Component) Blur() {}
 
 // Focusables satisfies FocusableSet; the base model provides the trace list focusable.
-func (t *Component) Focusables() map[string]topics.Focusable { return map[string]topics.Focusable{} }
+func (t *Component) Focusables() map[string]focus.Focusable { return map[string]focus.Focusable{} }
 
 // List exposes the trace configuration list model.
 func (t *Component) List() *list.Model { return &t.list }


### PR DESCRIPTION
## Summary
- centralize focus interfaces and adapters in new focus package
- update components to use shared focus.Adapt instead of local copies
- wire model and topics to the common focus map helper

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689055e110208324b4360c198eb0f030