### PR TITLE
refactor: modularize client update handlers

### DIFF
--- a/inputs.go
+++ b/inputs.go
@@ -1,0 +1,73 @@
+package emqutiti
+
+import (
+	list "github.com/charmbracelet/bubbles/list"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/history"
+)
+
+// updateClientInputs updates form inputs, viewport and history list.
+func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
+	var cmds []tea.Cmd
+	if cmd := m.topics.UpdateInput(msg); cmd != nil {
+		cmds = append(cmds, cmd)
+	}
+	if mCmd := m.message.Update(msg); mCmd != nil {
+		cmds = append(cmds, mCmd)
+	}
+	if vpCmd := m.updateViewport(msg); vpCmd != nil {
+		cmds = append(cmds, vpCmd)
+	}
+	if m.FocusedID() == idHistory {
+		if histCmd := m.history.Update(msg); histCmd != nil {
+			cmds = append(cmds, histCmd)
+		}
+	}
+	return cmds
+}
+
+// updateViewport updates the main viewport unless history handles the scroll.
+func (m *model) updateViewport(msg tea.Msg) tea.Cmd {
+	skipVP := false
+	if m.FocusedID() == idHistory {
+		switch mt := msg.(type) {
+		case tea.KeyMsg:
+			s := mt.String()
+			if s == "up" || s == "down" || s == "pgup" || s == "pgdown" || s == "k" || s == "j" {
+				skipVP = true
+			}
+		case tea.MouseMsg:
+			if mt.Action == tea.MouseActionPress && (mt.Button == tea.MouseButtonWheelUp || mt.Button == tea.MouseButtonWheelDown) {
+				skipVP = true
+			}
+		}
+	}
+	if skipVP {
+		return nil
+	}
+	var cmd tea.Cmd
+	m.ui.viewport, cmd = m.ui.viewport.Update(msg)
+	return cmd
+}
+
+// filterHistoryList refreshes history items based on the current filter state.
+func (m *model) filterHistoryList() {
+	if st := m.history.List().FilterState(); st == list.Filtering || st == list.FilterApplied {
+		q := m.history.List().FilterInput.Value()
+		hitems, litems := history.ApplyFilter(q, m.history.Store(), m.history.ShowArchived())
+		m.history.SetItems(hitems)
+		m.history.SetFilterQuery(q)
+		m.history.List().SetItems(litems)
+	} else if m.history.FilterQuery() != "" {
+		hitems, litems := history.ApplyFilter(m.history.FilterQuery(), m.history.Store(), m.history.ShowArchived())
+		m.history.SetItems(hitems)
+		m.history.List().SetItems(litems)
+	} else {
+		items := make([]list.Item, len(m.history.Items()))
+		for i, it := range m.history.Items() {
+			items[i] = it
+		}
+		m.history.List().SetItems(items)
+	}
+}

--- a/mouse.go
+++ b/mouse.go
@@ -1,0 +1,64 @@
+package emqutiti
+
+import tea "github.com/charmbracelet/bubbletea"
+
+// isHistoryFocused reports if the history list has focus.
+func (m *model) isHistoryFocused() bool {
+	return m.FocusedID() == idHistory
+}
+
+// isTopicsFocused reports if the topics view has focus.
+func (m *model) isTopicsFocused() bool {
+	return m.FocusedID() == idTopics
+}
+
+// handleMouseScroll processes scroll wheel events.
+// It returns a command and a boolean indicating if the event was handled.
+func (m *model) handleMouseScroll(msg tea.MouseMsg) (tea.Cmd, bool) {
+	if msg.Action == tea.MouseActionPress && (msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown) {
+		if m.isHistoryFocused() && !m.history.ShowArchived() {
+			return m.history.Scroll(msg), true
+		}
+		if m.isTopicsFocused() {
+			delta := -1
+			if msg.Button == tea.MouseButtonWheelDown {
+				delta = 1
+			}
+			m.topics.Scroll(delta)
+			return nil, true
+		}
+		return nil, true
+	}
+	return nil, false
+}
+
+// handleMouseLeft manages left-click focus and selection.
+func (m *model) handleMouseLeft(msg tea.MouseMsg) tea.Cmd {
+	cmd := m.focusFromMouse(msg.Y)
+	if m.isHistoryFocused() && !m.history.ShowArchived() {
+		m.history.HandleClick(msg, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
+	}
+	return cmd
+}
+
+// handleClientMouse processes mouse events in client mode.
+func (m *model) handleClientMouse(msg tea.MouseMsg) tea.Cmd {
+	if cmd, handled := m.handleMouseScroll(msg); handled {
+		return cmd
+	}
+	var cmds []tea.Cmd
+	if msg.Type == tea.MouseLeft {
+		if cmd := m.handleMouseLeft(msg); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if msg.Type == tea.MouseLeft || msg.Type == tea.MouseRight {
+		if cmd := m.topics.HandleClick(msg, m.ui.viewport.YOffset); cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	}
+	if len(cmds) == 0 {
+		return nil
+	}
+	return tea.Batch(cmds...)
+}

--- a/status.go
+++ b/status.go
@@ -1,0 +1,39 @@
+package emqutiti
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	connections "github.com/marang/emqutiti/connections"
+)
+
+// handleStatusMessage processes broker status updates.
+func (m *model) handleStatusMessage(msg connections.StatusMessage) tea.Cmd {
+	m.history.Append("", string(msg), "log", string(msg))
+	if strings.HasPrefix(string(msg), "Connected") && m.connections.Active != "" {
+		m.connections.SetConnected(m.connections.Active)
+		m.connections.RefreshConnectionItems()
+		m.connectionsAPI().SubscribeActiveTopics()
+	} else if strings.HasPrefix(string(msg), "Connection lost") && m.connections.Active != "" {
+		m.connections.SetDisconnected(m.connections.Active, "")
+		m.connections.RefreshConnectionItems()
+	}
+	return m.connections.ListenStatus()
+}
+
+// handleMQTTMessage appends received MQTT messages to history.
+func (m *model) handleMQTTMessage(msg MQTTMessage) tea.Cmd {
+	m.history.Append(msg.Topic, msg.Payload, "sub", fmt.Sprintf("Received on %s: %s", msg.Topic, msg.Payload))
+	return listenMessages(m.mqttClient.MessageChan)
+}
+
+// updateClientStatus returns commands to listen for connection and message updates.
+func (m *model) updateClientStatus() []tea.Cmd {
+	cmds := []tea.Cmd{m.connections.ListenStatus()}
+	if m.mqttClient != nil {
+		cmds = append(cmds, listenMessages(m.mqttClient.MessageChan))
+	}
+	return cmds
+}

--- a/update_client.go
+++ b/update_client.go
@@ -2,36 +2,13 @@ package emqutiti
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/marang/emqutiti/clientkeys"
 	connections "github.com/marang/emqutiti/connections"
-	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/topics"
 )
-
-// handleStatusMessage processes broker status updates.
-func (m *model) handleStatusMessage(msg connections.StatusMessage) tea.Cmd {
-	m.history.Append("", string(msg), "log", string(msg))
-	if strings.HasPrefix(string(msg), "Connected") && m.connections.Active != "" {
-		m.connections.SetConnected(m.connections.Active)
-		m.connections.RefreshConnectionItems()
-		m.connectionsAPI().SubscribeActiveTopics()
-	} else if strings.HasPrefix(string(msg), "Connection lost") && m.connections.Active != "" {
-		m.connections.SetDisconnected(m.connections.Active, "")
-		m.connections.RefreshConnectionItems()
-	}
-	return m.connections.ListenStatus()
-}
-
-// handleMQTTMessage appends received MQTT messages to history.
-func (m *model) handleMQTTMessage(msg MQTTMessage) tea.Cmd {
-	m.history.Append(msg.Topic, msg.Payload, "sub", fmt.Sprintf("Received on %s: %s", msg.Topic, msg.Payload))
-	return listenMessages(m.mqttClient.MessageChan)
-}
 
 // handleTopicToggle subscribes or unsubscribes from a topic and logs the action.
 func (m *model) handleTopicToggle(msg topics.ToggleMsg) tea.Cmd {
@@ -45,67 +22,6 @@ func (m *model) handleTopicToggle(msg topics.ToggleMsg) tea.Cmd {
 		}
 	}
 	return nil
-}
-
-// isHistoryFocused reports if the history list has focus.
-func (m *model) isHistoryFocused() bool {
-	return m.FocusedID() == idHistory
-}
-
-// isTopicsFocused reports if the topics view has focus.
-func (m *model) isTopicsFocused() bool {
-	return m.FocusedID() == idTopics
-}
-
-// handleMouseScroll processes scroll wheel events.
-// It returns a command and a boolean indicating if the event was handled.
-func (m *model) handleMouseScroll(msg tea.MouseMsg) (tea.Cmd, bool) {
-	if msg.Action == tea.MouseActionPress && (msg.Button == tea.MouseButtonWheelUp || msg.Button == tea.MouseButtonWheelDown) {
-		if m.isHistoryFocused() && !m.history.ShowArchived() {
-			return m.history.Scroll(msg), true
-		}
-		if m.isTopicsFocused() {
-			delta := -1
-			if msg.Button == tea.MouseButtonWheelDown {
-				delta = 1
-			}
-			m.topics.Scroll(delta)
-			return nil, true
-		}
-		return nil, true
-	}
-	return nil, false
-}
-
-// handleMouseLeft manages left-click focus and selection.
-func (m *model) handleMouseLeft(msg tea.MouseMsg) tea.Cmd {
-	cmd := m.focusFromMouse(msg.Y)
-	if m.isHistoryFocused() && !m.history.ShowArchived() {
-		m.history.HandleClick(msg, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
-	}
-	return cmd
-}
-
-// handleClientMouse processes mouse events in client mode.
-func (m *model) handleClientMouse(msg tea.MouseMsg) tea.Cmd {
-	if cmd, handled := m.handleMouseScroll(msg); handled {
-		return cmd
-	}
-	var cmds []tea.Cmd
-	if msg.Type == tea.MouseLeft {
-		if cmd := m.handleMouseLeft(msg); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-	}
-	if msg.Type == tea.MouseLeft || msg.Type == tea.MouseRight {
-		if cmd := m.topics.HandleClick(msg, m.ui.viewport.YOffset); cmd != nil {
-			cmds = append(cmds, cmd)
-		}
-	}
-	if len(cmds) == 0 {
-		return nil
-	}
-	return tea.Batch(cmds...)
 }
 
 // updateClient updates the UI when in client mode.
@@ -126,15 +42,6 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
-// updateClientStatus returns commands to listen for connection and message updates.
-func (m *model) updateClientStatus() []tea.Cmd {
-	cmds := []tea.Cmd{m.connections.ListenStatus()}
-	if m.mqttClient != nil {
-		cmds = append(cmds, listenMessages(m.mqttClient.MessageChan))
-	}
-	return cmds
-}
-
 // handleClientMsg dispatches client messages and returns a command.
 // The boolean indicates if processing should stop after the command.
 func (m *model) handleClientMsg(msg tea.Msg) (tea.Cmd, bool) {
@@ -149,69 +56,4 @@ func (m *model) handleClientMsg(msg tea.Msg) (tea.Cmd, bool) {
 		return m.handleClientMouse(t), false
 	}
 	return nil, false
-}
-
-// updateClientInputs updates form inputs, viewport and history list.
-func (m *model) updateClientInputs(msg tea.Msg) []tea.Cmd {
-	var cmds []tea.Cmd
-	if cmd := m.topics.UpdateInput(msg); cmd != nil {
-		cmds = append(cmds, cmd)
-	}
-	if mCmd := m.message.Update(msg); mCmd != nil {
-		cmds = append(cmds, mCmd)
-	}
-	if vpCmd := m.updateViewport(msg); vpCmd != nil {
-		cmds = append(cmds, vpCmd)
-	}
-	if m.FocusedID() == idHistory {
-		if histCmd := m.history.Update(msg); histCmd != nil {
-			cmds = append(cmds, histCmd)
-		}
-	}
-	return cmds
-}
-
-// updateViewport updates the main viewport unless history handles the scroll.
-func (m *model) updateViewport(msg tea.Msg) tea.Cmd {
-	skipVP := false
-	if m.FocusedID() == idHistory {
-		switch mt := msg.(type) {
-		case tea.KeyMsg:
-			s := mt.String()
-			if s == "up" || s == "down" || s == "pgup" || s == "pgdown" || s == "k" || s == "j" {
-				skipVP = true
-			}
-		case tea.MouseMsg:
-			if mt.Action == tea.MouseActionPress && (mt.Button == tea.MouseButtonWheelUp || mt.Button == tea.MouseButtonWheelDown) {
-				skipVP = true
-			}
-		}
-	}
-	if skipVP {
-		return nil
-	}
-	var cmd tea.Cmd
-	m.ui.viewport, cmd = m.ui.viewport.Update(msg)
-	return cmd
-}
-
-// filterHistoryList refreshes history items based on the current filter state.
-func (m *model) filterHistoryList() {
-	if st := m.history.List().FilterState(); st == list.Filtering || st == list.FilterApplied {
-		q := m.history.List().FilterInput.Value()
-		hitems, litems := history.ApplyFilter(q, m.history.Store(), m.history.ShowArchived())
-		m.history.SetItems(hitems)
-		m.history.SetFilterQuery(q)
-		m.history.List().SetItems(litems)
-	} else if m.history.FilterQuery() != "" {
-		hitems, litems := history.ApplyFilter(m.history.FilterQuery(), m.history.Store(), m.history.ShowArchived())
-		m.history.SetItems(hitems)
-		m.history.List().SetItems(litems)
-	} else {
-		items := make([]list.Item, len(m.history.Items()))
-		for i, it := range m.history.Items() {
-			items[i] = it
-		}
-		m.history.List().SetItems(items)
-	}
 }


### PR DESCRIPTION
## Summary
- isolate status handling in new `status.go`
- move mouse logic to `mouse.go`
- move input and viewport updates to `inputs.go`
- keep `updateClient` coordinating across new modules

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68905e3df49083248fba00058a24e2d8