### PR TITLE
export history query parser

### DIFF
--- a/history/history_component.go
+++ b/history/history_component.go
@@ -81,7 +81,7 @@ func (h *Component) UpdateFilter(msg tea.Msg) tea.Cmd {
 			return cmd
 		case "enter":
 			q := h.filterForm.query()
-			topics, start, end, payload := parseHistoryQuery(q)
+			topics, start, end, payload := ParseQuery(q)
 			var msgs []Message
 			if h.showArchived {
 				msgs = h.store.Search(true, topics, start, end, payload)

--- a/history/history_util.go
+++ b/history/history_util.go
@@ -27,7 +27,7 @@ func ApplyFilter(q string, store Store, archived bool) ([]Item, []list.Item) {
 	if store == nil {
 		return nil, nil
 	}
-	topics, start, end, payload := parseHistoryQuery(q)
+	topics, start, end, payload := ParseQuery(q)
 	var msgs []Message
 	if archived {
 		msgs = store.Search(true, topics, start, end, payload)

--- a/history/historystore.go
+++ b/history/historystore.go
@@ -195,13 +195,13 @@ func (i *store) Count(archived bool) int {
 	return c
 }
 
-// parseHistoryQuery interprets a filter string in the form:
+// ParseQuery interprets a filter string in the form:
 //
 //	"topic=a,b start=2023-01-02T15:04:05Z end=2023-01-02T16:00 payload=foo".
 //
 // Fields may appear in any order and are optional. Unrecognised tokens are
 // treated as payload search text.
-func parseHistoryQuery(q string) (topics []string, start, end time.Time, payload string) {
+func ParseQuery(q string) (topics []string, start, end time.Time, payload string) {
 	var payloadParts []string
 	for _, f := range strings.Fields(q) {
 		switch {

--- a/history/historystore_query_test.go
+++ b/history/historystore_query_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func TestParseHistoryQuery(t *testing.T) {
+func TestParseQuery(t *testing.T) {
 	cases := []struct {
 		query   string
 		topics  []string
@@ -52,7 +52,7 @@ func TestParseHistoryQuery(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		gotTopics, gotStart, gotEnd, gotPayload := parseHistoryQuery(c.query)
+		gotTopics, gotStart, gotEnd, gotPayload := ParseQuery(c.query)
 
 		if !reflect.DeepEqual(gotTopics, c.topics) {
 			t.Errorf("topics mismatch for %q: %v != %v", c.query, gotTopics, c.topics)

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -65,7 +65,7 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	var topic, payload string
 	var start, end time.Time
 	if m.history.FilterQuery() != "" {
-		ts, s, e, p := parseHistoryQuery(m.history.FilterQuery())
+		ts, s, e, p := history.ParseQuery(m.history.FilterQuery())
 		if len(ts) > 0 {
 			topic = ts[0]
 		}

--- a/model_history.go
+++ b/model_history.go
@@ -140,36 +140,6 @@ func (f historyFilterForm) query() string {
 	return strings.Join(parts, " ")
 }
 
-// parseHistoryQuery interprets a filter string.
-func parseHistoryQuery(q string) (topics []string, start, end time.Time, payload string) {
-	var payloadParts []string
-	for _, f := range strings.Fields(q) {
-		switch {
-		case strings.HasPrefix(f, "topic="):
-			ts := strings.TrimPrefix(f, "topic=")
-			if ts != "" {
-				topics = strings.Split(ts, ",")
-			}
-		case strings.HasPrefix(f, "start="):
-			t, err := time.Parse(time.RFC3339, strings.TrimPrefix(f, "start="))
-			if err == nil {
-				start = t
-			}
-		case strings.HasPrefix(f, "end="):
-			t, err := time.Parse(time.RFC3339, strings.TrimPrefix(f, "end="))
-			if err == nil {
-				end = t
-			}
-		case strings.HasPrefix(f, "payload="):
-			payloadParts = append(payloadParts, strings.TrimPrefix(f, "payload="))
-		default:
-			payloadParts = append(payloadParts, f)
-		}
-	}
-	payload = strings.Join(payloadParts, " ")
-	return
-}
-
 // historyStore provides an in-memory implementation of history.Store for tests.
 type historyStore struct{ msgs []history.Message }
 


### PR DESCRIPTION
## Summary
- export history query parser for reuse
- drop duplicate parser in model
- update callers to use history.ParseQuery

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890643537308324b1af3cf957df4623