### PR TITLE
refactor connections api

### DIFF
--- a/connections/api.go
+++ b/connections/api.go
@@ -12,24 +12,15 @@ type Client interface {
 }
 
 // ConnectResult represents the outcome of a connection attempt.
-type ConnectResult interface {
-	Client() Client
-	Profile() Profile
-	Err() error
-}
-
-// ConnectionStatusManager exposes methods to update connection status
-// information.
-type ConnectionStatusManager interface {
-	SetConnecting(name string)
-	SetConnected(name string)
-	SetDisconnected(name, detail string)
+type ConnectResult struct {
+	Client  Client
+	Profile Profile
+	Err     error
 }
 
 // API defines the methods used by the connections component to interact
 // with the application without depending on concrete model types.
 type API interface {
-	ConnectionStatusManager
 	Manager() *Connections
 	ListenStatus() tea.Cmd
 	SendStatus(string)
@@ -49,6 +40,9 @@ type API interface {
 	ResetElemPos()
 	SetElemPos(id string, pos int)
 	OverlayHelp(view string) string
+	SetConnecting(name string)
+	SetConnected(name string)
+	SetDisconnected(name, detail string)
 }
 
 // Navigator exposes navigation helpers required by the component.

--- a/connections/component.go
+++ b/connections/component.go
@@ -45,8 +45,6 @@ type State struct {
 	Saved       map[string]ConnectionSnapshot
 }
 
-var _ ConnectionStatusManager = (*State)(nil)
-
 // SetConnecting marks the named connection as in progress.
 func (c *State) SetConnecting(name string) {
 	c.Manager.Statuses[name] = "connecting"
@@ -127,7 +125,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 	switch msg := msg.(type) {
 	case ConnectResult:
 		c.api.HandleConnectResult(msg)
-		if msg.Err() == nil {
+		if msg.Err == nil {
 			cmd = c.nav.SetMode(modeClient)
 			return tea.Batch(cmd, c.api.ListenStatus())
 		}

--- a/model_init.go
+++ b/model_init.go
@@ -124,7 +124,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.message = msgComp
 	m.help = help.New(navAdapter{m}, &m.ui.width, &m.ui.height, &m.ui.elemPos)
 	m.confirm = confirm.NewComponent(m, m, nil, nil, nil)
-	connComp := connections.NewComponent(navAdapter{m}, m.connectionsAPI())
+	connComp := connections.NewComponent(navAdapter{m}, m)
 	topicsComp := topics.New(m)
 	m.topics = topicsComp
 	m.payloads = payloads.New(m, &m.connections)

--- a/status.go
+++ b/status.go
@@ -15,7 +15,7 @@ func (m *model) handleStatusMessage(msg connections.StatusMessage) tea.Cmd {
 	if strings.HasPrefix(string(msg), "Connected") && m.connections.Active != "" {
 		m.connections.SetConnected(m.connections.Active)
 		m.connections.RefreshConnectionItems()
-		m.connectionsAPI().SubscribeActiveTopics()
+		m.SubscribeActiveTopics()
 	} else if strings.HasPrefix(string(msg), "Connection lost") && m.connections.Active != "" {
 		m.connections.SetDisconnected(m.connections.Active, "")
 		m.connections.RefreshConnectionItems()

--- a/update_connection.go
+++ b/update_connection.go
@@ -7,16 +7,6 @@ import (
 	connections "github.com/marang/emqutiti/connections"
 )
 
-type connectResult struct {
-	client  *MQTTClient
-	profile connections.Profile
-	err     error
-}
-
-func (r connectResult) Client() connections.Client   { return r.client }
-func (r connectResult) Profile() connections.Profile { return r.profile }
-func (r connectResult) Err() error                   { return r.err }
-
 // statusFunc reports connection status messages.
 type statusFunc func(string)
 
@@ -28,7 +18,7 @@ func connectBroker(p connections.Profile, fn statusFunc) tea.Cmd {
 			fn(fmt.Sprintf("Connecting to %s", brokerURL))
 		}
 		client, err := NewMQTTClient(p, fn)
-		return connectResult{client: client, profile: p, err: err}
+		return connections.ConnectResult{Client: client, Profile: p, Err: err}
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace ConnectResult interface with struct and drop ConnectionStatusManager indirection
- implement connections.API directly on model and remove adapter
- update call sites for new API

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68906a450c848324bb4505f35f43231c