### PR TITLE
Guard FocusMap from nil elements

### DIFF
--- a/focus/focusmap.go
+++ b/focus/focusmap.go
@@ -50,7 +50,7 @@ type FocusMap struct {
 // NewFocusMap creates a FocusMap and focuses the first element if present.
 func NewFocusMap(items []Focusable) *FocusMap {
 	fm := &FocusMap{items: items}
-	if len(items) > 0 {
+	if len(items) > 0 && items[0] != nil {
 		items[0].Focus()
 	}
 	return fm

--- a/focus/focusmap_test.go
+++ b/focus/focusmap_test.go
@@ -1,0 +1,23 @@
+package focus
+
+import "testing"
+
+// stubFocusable implements focus.Focusable for testing.
+type stubFocusable struct{ focused bool }
+
+func (s *stubFocusable) Focus()          { s.focused = true }
+func (s *stubFocusable) Blur()           { s.focused = false }
+func (s *stubFocusable) IsFocused() bool { return s.focused }
+func (s *stubFocusable) View() string    { return "" }
+
+// TestNewFocusMapNilFirst ensures a nil first element doesn't panic or focus others.
+func TestNewFocusMapNilFirst(t *testing.T) {
+	second := &stubFocusable{}
+	fm := NewFocusMap([]Focusable{nil, second})
+	if fm.Index() != 0 {
+		t.Fatalf("expected index 0, got %d", fm.Index())
+	}
+	if second.IsFocused() {
+		t.Fatalf("second element should not be focused")
+	}
+}

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -110,7 +110,11 @@ func (m *model) setMode(mode appMode) tea.Cmd {
 	m.ui.focusOrder = append([]string(nil), order...)
 	items := make([]focus.Focusable, len(order))
 	for i, id := range order {
-		items[i] = m.focusables[id]
+		if f := m.focusables[id]; f != nil {
+			items[i] = f
+		} else {
+			items[i] = &focus.NullFocusable{}
+		}
 	}
 	m.focus = focus.NewFocusMap(items)
 	m.ui.focusIndex = m.focus.Index()


### PR DESCRIPTION
## Summary
- avoid nil dereference in FocusMap by checking first element
- replace missing focusables with NullFocusable when building focus list
- test nil-first-element case in FocusMap

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68906ceb72108324b05f36396b70715e