### PR TITLE
Rename update connection form handler

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -151,7 +151,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.components = map[appMode]Component{
 		modeClient:         component{update: m.updateClient, view: m.viewClient},
 		modeConnections:    connComp,
-		modeEditConnection: component{update: m.updateForm, view: m.viewForm},
+		modeEditConnection: component{update: m.updateConnectionForm, view: m.viewForm},
 		modeConfirmDelete:  m.confirm,
 		modeTopics:         topicsComp,
 		modePayloads:       m.payloads,

--- a/update_connection_form.go
+++ b/update_connection_form.go
@@ -2,8 +2,8 @@ package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 
-// updateForm handles the add/edit connection form.
-func (m *model) updateForm(msg tea.Msg) tea.Cmd {
+// updateConnectionForm handles the add/edit connection form.
+func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
 	if m.connections.Form == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary
- rename update_form.go to update_connection_form.go
- rename updateForm to updateConnectionForm and update references

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68906f4f22e08324bcf56cf6a10af63d