### PR TITLE
Fix trace save wiping config

### DIFF
--- a/traces/state.go
+++ b/traces/state.go
@@ -49,21 +49,20 @@ func saveTraces(data map[string]TracerConfig) {
 	if err != nil {
 		return
 	}
-	var cfg struct {
-		Traces map[string]persistedTrace `toml:"traces"`
-	}
+	cfg := map[string]interface{}{}
 	toml.DecodeFile(fp, &cfg) // ignore errors for new files
-	cfg.Traces = make(map[string]persistedTrace)
+	traces := map[string]interface{}{}
 	for k, v := range data {
-		pt := persistedTrace{Profile: v.Profile, Topics: v.Topics}
+		sub := map[string]interface{}{"profile": v.Profile, "topics": v.Topics}
 		if !v.Start.IsZero() {
-			pt.Start = v.Start.Format(time.RFC3339)
+			sub["start"] = v.Start.Format(time.RFC3339)
 		}
 		if !v.End.IsZero() {
-			pt.End = v.End.Format(time.RFC3339)
+			sub["end"] = v.End.Format(time.RFC3339)
 		}
-		cfg.Traces[k] = pt
+		traces[k] = sub
 	}
+	cfg["traces"] = traces
 	var buf bytes.Buffer
 	toml.NewEncoder(&buf).Encode(cfg)
 	os.MkdirAll(filepath.Dir(fp), os.ModePerm)

--- a/traces/state_test.go
+++ b/traces/state_test.go
@@ -1,0 +1,41 @@
+package traces
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/marang/emqutiti/connections"
+)
+
+func TestSaveTracesPreservesExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgPath, err := connections.DefaultUserConfigFile()
+	if err != nil {
+		t.Fatalf("cfg path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, []byte("default_profile = \"foo\"\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	data := map[string]TracerConfig{
+		"t1": {Profile: "p1", Topics: []string{"a"}, Start: time.Unix(0, 0)},
+	}
+	saveTraces(data)
+	out, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "default_profile") {
+		t.Fatalf("missing existing fields: %s", s)
+	}
+	if !strings.Contains(s, "[traces]") {
+		t.Fatalf("missing traces section: %s", s)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve existing config fields when saving traces
- add test ensuring trace save retains other settings

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688fa1790cd48324a06d334d48cf9aec