### PR TITLE
docs: update config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Emqutiti is a polished MQTT client for the terminal built on
 [Bubble Tea](https://github.com/charmbracelet/bubbletea). Profiles live in
-`~/.emqutiti/config.toml` so you can switch brokers with a few key presses. The
+`~/.config/emqutiti/config.toml` so you can switch brokers with a few key presses. The
 short demo below shows the app in action.
 
 ## Features
@@ -38,10 +38,10 @@ Press `Ctrl+R` in the UI to manage recorded traces.
 
 ### Headless tracing
 
-Use `emqutiti --trace myrun --topics "sensors/#" -p local` to capture messages without the UI. Traces are stored under `~/.emqutiti/data/<profile>/traces` and can be viewed in the application (run `emqutiti` and press `CTRL+R` in the app to view traces)
+Use `emqutiti --trace myrun --topics "sensors/#" -p local` to capture messages without the UI. Traces are stored under `~/.config/emqutiti/data/<profile>/traces` and can be viewed in the application (run `emqutiti` and press `CTRL+R` in the app to view traces)
 
 ## Configuration
-stored in `~/.emqutiti/config.toml` describing broker profiles. You can also create connections within the UI.
+stored in `~/.config/emqutiti/config.toml` describing broker profiles. You can also create connections within the UI.
 
 Minimal config example:
 

--- a/docs/scripts/Dockerfile.cast
+++ b/docs/scripts/Dockerfile.cast
@@ -16,7 +16,7 @@ COPY . .
 RUN go build -o emqutiti .
 
 # Prepare default config
-# RUN mkdir -p /root/.emqutiti && \
+# RUN mkdir -p /root/.config/emqutiti && \
 #     printf '%s\n' \
 #     'default_profile = "HiveMQ"' \
 #     '' \
@@ -29,7 +29,7 @@ RUN go build -o emqutiti .
 #     '  ssl_tls = true' \
 #     '  mqtt_version = "3"' \
 #     '  clean_start = false' \
-#     > /root/.emqutiti/config.toml
+#     > /root/.config/emqutiti/config.toml
 
 ENV PATH="/root/.cargo/bin:$PATH"
 ENV HOME="/root"

--- a/docs/scripts/record_casts.sh
+++ b/docs/scripts/record_casts.sh
@@ -4,8 +4,8 @@
 set -euo pipefail
 
 restore_config() {
-    mkdir -p /root/.emqutiti
-    cat > /root/.emqutiti/config.toml <<EOF
+    mkdir -p /root/.config/emqutiti
+    cat > /root/.config/emqutiti/config.toml <<EOF
 default_profile = "HiveMQ"
 
 [[profiles]]


### PR DESCRIPTION
## Summary
- fix docs to reference `~/.config/emqutiti`
- update helper scripts to create config in XDG path

## Testing
- `bash -n docs/scripts/record_casts.sh`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890786b5da48324ac8bc81bdb1401f8