### PR TITLE
Use XDG config directories

### DIFF
--- a/connections/profile_config.go
+++ b/connections/profile_config.go
@@ -14,13 +14,13 @@ type Config struct {
 	Profiles       []Profile `toml:"profiles"`
 }
 
-// DefaultUserConfigFile returns ~/.emqutiti/config.toml.
+// DefaultUserConfigFile returns ~/.config/emqutiti/config.toml.
 func DefaultUserConfigFile() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".emqutiti", "config.toml"), nil
+	return filepath.Join(home, ".config", "emqutiti", "config.toml"), nil
 }
 
 // LoadConfig reads profiles from a TOML file and resolves keyring references.

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -7,7 +7,7 @@ import (
 
 // DataDir returns the base data directory for the given profile.
 // If the profile is empty, "default" is used.
-// The directory is placed under ~/.emqutiti/data.
+// The directory is placed under ~/.config/emqutiti/data.
 func DataDir(profile string) string {
 	if profile == "" {
 		profile = "default"
@@ -16,7 +16,7 @@ func DataDir(profile string) string {
 	if err != nil {
 		return filepath.Join("data", profile)
 	}
-	return filepath.Join(home, ".emqutiti", "data", profile)
+	return filepath.Join(home, ".config", "emqutiti", "data", profile)
 }
 
 // EnsureDir creates the directory with 0755 permissions if it does not exist.

--- a/main_test.go
+++ b/main_test.go
@@ -14,7 +14,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	os.Setenv("HOME", dir)
-	cfgDir := filepath.Join(dir, ".emqutiti")
+	cfgDir := filepath.Join(dir, ".config", "emqutiti")
 	os.MkdirAll(cfgDir, 0o755)
 	os.WriteFile(filepath.Join(cfgDir, "config.toml"), []byte{}, 0o644)
 	code := m.Run()


### PR DESCRIPTION
## Summary
- read user config from ~/.config/emqutiti/config.toml
- store profile data under ~/.config/emqutiti/data
- update tests to use new config path

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890786b6dc48324950d245e241e836b