### PR TITLE
Auto-connect default profile and toggle via UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ yay -S emqutiti
 emqutiti
 ```
 
+If a profile is marked as default, the app connects to it automatically on start.
+
 ### Importing from CSV or XLS
 
 Launch `emqutiti --import data.csv -p local` to map columns to JSON and publish them. The wizard supports dry runs and will remember settings in future versions.
@@ -63,6 +65,7 @@ Tips:
 - Enable **Load from env** to read variables such as `EMQUTITI_LOCAL_BROKER_PASSWORD`.
 
 - Set `EMQUTITI_DEFAULT_PASSWORD` to override profile passwords when not loading from env.
+- Set `default_profile` to auto-connect on launch. Use `Ctrl+O` in the broker manager to toggle it.
 
 ### Shortcuts
 
@@ -92,6 +95,7 @@ Tips:
 #### Broker Manager
 
 - `x` disconnects the selected profile
+- `Ctrl+O` toggles the default profile
 
 #### History View
 

--- a/connections/component.go
+++ b/connections/component.go
@@ -81,13 +81,7 @@ func (c *State) FlushStatus() { FlushStatus(c.StatusChan) }
 // RefreshConnectionItems rebuilds the connections list to show status
 // information.
 func (c *State) RefreshConnectionItems() {
-	items := []list.Item{}
-	for _, p := range c.Manager.Profiles {
-		status := c.Manager.Statuses[p.Name]
-		detail := c.Manager.Errors[p.Name]
-		items = append(items, connectionItem{title: p.Name, status: status, detail: detail})
-	}
-	c.Manager.ConnectionsList.SetItems(items)
+	c.Manager.refreshList()
 }
 
 // SaveCurrent persists topics and payloads for the active connection.
@@ -156,6 +150,15 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 		case "ctrl+r":
 			c.api.ResizeTraces(c.nav.Width()-4, c.nav.Height()-4)
 			return c.nav.SetMode(modeTracer)
+		case "ctrl+o":
+			i := mgr.ConnectionsList.Index()
+			if i >= 0 {
+				if mgr.DefaultProfileName == mgr.Profiles[i].Name {
+					mgr.ClearDefault()
+				} else {
+					mgr.SetDefault(i)
+				}
+			}
 		case "a":
 			c.api.BeginAdd()
 			return c.nav.SetMode(modeEditConnection)
@@ -198,7 +201,7 @@ func (c *Component) View() string {
 	c.api.ResetElemPos()
 	c.api.SetElemPos(idConnList, 1)
 	listView := c.api.Manager().ConnectionsList.View()
-	help := ui.InfoStyle.Render("[enter] connect/open client  [x] disconnect  [a]dd [e]dit [del] delete  Ctrl+R traces")
+	help := ui.InfoStyle.Render("[enter] connect/open client  [x] disconnect  [a]dd [e]dit [del] delete  Ctrl+O default  Ctrl+R traces")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
 	view := ui.LegendBox(content, "Brokers", c.nav.Width()-2, 0, ui.ColBlue, true, -1)
 	return c.api.OverlayHelp(view)

--- a/default_profile_test.go
+++ b/default_profile_test.go
@@ -1,0 +1,27 @@
+package emqutiti
+
+import (
+	"testing"
+
+	connections "github.com/marang/emqutiti/connections"
+)
+
+// Test that Init connects using the default profile when no profile flag is set.
+func TestInitConnectsDefaultProfile(t *testing.T) {
+	origProfile := profileName
+	profileName = ""
+	defer func() { profileName = origProfile }()
+
+	conn := connections.NewConnectionsModel()
+	conn.Profiles = []connections.Profile{{Name: "p1", Schema: "tcp", Host: "h", Port: 1883}}
+	conn.DefaultProfileName = "p1"
+
+	m, _ := initialModel(&conn)
+	cmd := m.Init()
+	if m.connections.Manager.Statuses["p1"] != "connecting" {
+		t.Fatalf("expected status 'connecting', got %q", m.connections.Manager.Statuses["p1"])
+	}
+	if cmd == nil {
+		t.Fatalf("expected connect command")
+	}
+}

--- a/docs/help.md
+++ b/docs/help.md
@@ -33,6 +33,7 @@
 ## Broker Manager
 
 - 'x' disconnects the selected profile
+- `Ctrl+O` toggles the default profile
 
 ## History View
 

--- a/model_init.go
+++ b/model_init.go
@@ -206,6 +206,17 @@ func initialModel(conns *connections.Connections) (*model, error) {
 }
 
 // Init enables initial Tea behavior such as mouse support.
-func (m model) Init() tea.Cmd {
-	return tea.EnableMouseCellMotion
+func (m *model) Init() tea.Cmd {
+	cmds := []tea.Cmd{tea.EnableMouseCellMotion}
+	if profileName == "" {
+		if name := m.connections.Manager.DefaultProfileName; name != "" {
+			for _, p := range m.connections.Manager.Profiles {
+				if p.Name == name {
+					cmds = append(cmds, m.Connect(p))
+					break
+				}
+			}
+		}
+	}
+	return tea.Batch(cmds...)
 }


### PR DESCRIPTION
## Summary
- Connect to the configured default profile automatically on startup
- Allow toggling the default profile from the broker list with `Ctrl+O`
- Document default profile usage and configuration

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890d9b38f90832499879a487dfc366a