### PR TITLE
Add archived filter option

### DIFF
--- a/history/history_component.go
+++ b/history/history_component.go
@@ -80,14 +80,10 @@ func (h *Component) UpdateFilter(msg tea.Msg) tea.Cmd {
 			cmd := tea.Batch(h.m.SetMode(h.m.PreviousMode()), h.m.SetFocus(ID))
 			return cmd
 		case "enter":
+			h.showArchived = h.filterForm.archived.Bool()
 			q := h.filterForm.query()
 			topics, start, end, payload := ParseQuery(q)
-			var msgs []Message
-			if h.showArchived {
-				msgs = h.store.Search(true, topics, start, end, payload)
-			} else {
-				msgs = h.store.Search(false, topics, start, end, payload)
-			}
+			msgs := h.store.Search(h.showArchived, topics, start, end, payload)
 			var items []list.Item
 			h.items, items = MessagesToItems(msgs)
 			h.list.SetItems(items)

--- a/history/historyfilter.go
+++ b/history/historyfilter.go
@@ -16,15 +16,17 @@ const (
 	idxFilterPayload
 	idxFilterStart
 	idxFilterEnd
+	idxFilterArchived
 )
 
 // historyFilterForm captures filter inputs for history searches.
 type historyFilterForm struct {
 	ui.Form
-	topic   *ui.SuggestField
-	payload *ui.TextField
-	start   *ui.TextField
-	end     *ui.TextField
+	topic    *ui.SuggestField
+	payload  *ui.TextField
+	start    *ui.TextField
+	end      *ui.TextField
+	archived *ui.CheckField
 }
 
 // Topic returns the topic field.
@@ -39,9 +41,12 @@ func (f *historyFilterForm) Start() *ui.TextField { return f.start }
 // End returns the end time field.
 func (f *historyFilterForm) End() *ui.TextField { return f.end }
 
+// Archived returns the archived checkbox field.
+func (f *historyFilterForm) Archived() *ui.CheckField { return f.archived }
+
 // newHistoryFilterForm builds a form with optional prefilled values.
 // Start and end remain blank when zero, allowing searches across all time.
-func newHistoryFilterForm(topics []string, topic, payload string, start, end time.Time) historyFilterForm {
+func newHistoryFilterForm(topics []string, topic, payload string, start, end time.Time, archived bool) historyFilterForm {
 	sort.Strings(topics)
 	tf := ui.NewSuggestField(topics, "topic")
 	tf.SetValue(topic)
@@ -59,20 +64,23 @@ func newHistoryFilterForm(topics []string, topic, payload string, start, end tim
 		ef.SetValue(end.Format(time.RFC3339))
 	}
 
+	af := ui.NewCheckField(archived)
+
 	f := historyFilterForm{
-		Form:    ui.Form{Fields: []ui.Field{tf, pf, sf, ef}},
-		topic:   tf,
-		payload: pf,
-		start:   sf,
-		end:     ef,
+		Form:     ui.Form{Fields: []ui.Field{tf, pf, sf, ef, af}},
+		topic:    tf,
+		payload:  pf,
+		start:    sf,
+		end:      ef,
+		archived: af,
 	}
 	f.ApplyFocus()
 	return f
 }
 
 // NewFilterForm builds a history filter form with optional prefilled values.
-func NewFilterForm(topics []string, topic, payload string, start, end time.Time) historyFilterForm {
-	return newHistoryFilterForm(topics, topic, payload, start, end)
+func NewFilterForm(topics []string, topic, payload string, start, end time.Time, archived bool) historyFilterForm {
+	return newHistoryFilterForm(topics, topic, payload, start, end, archived)
 }
 
 // Update handles focus cycling and topic completion.
@@ -116,6 +124,8 @@ func (f historyFilterForm) View() string {
 		fmt.Sprintf("Start: %s", f.start.View()),
 		"",
 		fmt.Sprintf("End:   %s", f.end.View()),
+		"",
+		fmt.Sprintf("Archived: %s", f.archived.View()),
 	)
 	return strings.Join(lines, "\n")
 }

--- a/history/historystore_query_test.go
+++ b/history/historystore_query_test.go
@@ -78,3 +78,20 @@ func TestParseQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestApplyFilterArchived(t *testing.T) {
+	hs := &store{}
+	ts := time.Now()
+	hs.Append(Message{Timestamp: ts, Topic: "t1", Payload: "active", Kind: "pub"})
+	hs.Append(Message{Timestamp: ts.Add(time.Second), Topic: "t2", Payload: "arch", Kind: "pub", Archived: true})
+
+	items, _ := ApplyFilter("", hs, false)
+	if len(items) != 1 || items[0].Archived {
+		t.Fatalf("expected 1 unarchived item, got %v", items)
+	}
+
+	items, _ = ApplyFilter("", hs, true)
+	if len(items) != 1 || !items[0].Archived {
+		t.Fatalf("expected 1 archived item, got %v", items)
+	}
+}

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -74,7 +74,7 @@ func (m *model) startHistoryFilter() tea.Cmd {
 		end = time.Now()
 		start = end.Add(-time.Hour)
 	}
-	hf := history.NewFilterForm(topics, topic, payload, start, end)
+	hf := history.NewFilterForm(topics, topic, payload, start, end, m.history.ShowArchived())
 	m.history.SetFilterForm(&hf)
 	return m.setMode(modeHistoryFilter)
 }

--- a/model_history.go
+++ b/model_history.go
@@ -34,10 +34,11 @@ func (a historyModelAdapter) OverlayHelp(s string) string { return a.model.Overl
 // historyFilterForm captures filter inputs for history searches.
 type historyFilterForm struct {
 	ui.Form
-	topic   *ui.SuggestField
-	payload *ui.TextField
-	start   *ui.TextField
-	end     *ui.TextField
+	topic    *ui.SuggestField
+	payload  *ui.TextField
+	start    *ui.TextField
+	end      *ui.TextField
+	archived *ui.CheckField
 }
 
 const (
@@ -45,10 +46,11 @@ const (
 	idxFilterPayload
 	idxFilterStart
 	idxFilterEnd
+	idxFilterArchived
 )
 
 // newHistoryFilterForm builds a form with optional prefilled values.
-func newHistoryFilterForm(topics []string, topic, payload string, start, end time.Time) historyFilterForm {
+func newHistoryFilterForm(topics []string, topic, payload string, start, end time.Time, archived bool) historyFilterForm {
 	sort.Strings(topics)
 	tf := ui.NewSuggestField(topics, "topic")
 	tf.SetValue(topic)
@@ -66,12 +68,15 @@ func newHistoryFilterForm(topics []string, topic, payload string, start, end tim
 		ef.SetValue(end.Format(time.RFC3339))
 	}
 
+	af := ui.NewCheckField(archived)
+
 	f := historyFilterForm{
-		Form:    ui.Form{Fields: []ui.Field{tf, pf, sf, ef}},
-		topic:   tf,
-		payload: pf,
-		start:   sf,
-		end:     ef,
+		Form:     ui.Form{Fields: []ui.Field{tf, pf, sf, ef, af}},
+		topic:    tf,
+		payload:  pf,
+		start:    sf,
+		end:      ef,
+		archived: af,
 	}
 	f.ApplyFocus()
 	return f
@@ -118,6 +123,8 @@ func (f historyFilterForm) View() string {
 		fmt.Sprintf("Start: %s", f.start.View()),
 		"",
 		fmt.Sprintf("End:   %s", f.end.View()),
+		"",
+		fmt.Sprintf("Archived: %s", f.archived.View()),
 	)
 	return strings.Join(lines, "\n")
 }

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -84,3 +84,32 @@ func TestHistoryFilterUpdatesCounts(t *testing.T) {
 		t.Fatalf("expected count in label, got %q", view)
 	}
 }
+
+// Test that the archived checkbox filters messages accordingly.
+func TestHistoryFilterArchived(t *testing.T) {
+	m, _ := initialModel(nil)
+	hs := &historyStore{}
+	m.history.SetStore(hs)
+	ts := time.Now()
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Archived: true})
+
+	// default unchecked state shows unarchived messages
+	m.startHistoryFilter()
+	m.history.FilterForm().Start().SetValue("")
+	m.history.FilterForm().End().SetValue("")
+	m.history.UpdateFilter(tea.KeyMsg{Type: tea.KeyEnter})
+	if len(m.history.Items()) != 1 || m.history.Items()[0].Archived {
+		t.Fatalf("expected one active message, got %v", m.history.Items())
+	}
+
+	// enabling checkbox returns archived messages
+	m.startHistoryFilter()
+	m.history.FilterForm().Start().SetValue("")
+	m.history.FilterForm().End().SetValue("")
+	m.history.FilterForm().Archived().SetBool(true)
+	m.history.UpdateFilter(tea.KeyMsg{Type: tea.KeyEnter})
+	if len(m.history.Items()) != 1 || !m.history.Items()[0].Archived {
+		t.Fatalf("expected one archived message, got %v", m.history.Items())
+	}
+}


### PR DESCRIPTION
## Summary
- add archived checkbox to history filter form
- allow history component and model to use archived flag
- test archived-only and active-only filtering

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890dab233dc8324a2c6f03c94da468b