### PR TITLE
style: color publish topic chips

### DIFF
--- a/topics/component.go
+++ b/topics/component.go
@@ -356,10 +356,10 @@ func (c *Component) EnsureVisible(width int) {
 	for _, t := range c.Items {
 		st := ui.ChipStyle
 		switch {
-		case !t.Subscribed:
-			st = ui.ChipInactive
 		case t.Publish:
 			st = ui.ChipPublish
+		case !t.Subscribed:
+			st = ui.ChipInactive
 		}
 		chips = append(chips, st.Render(t.Name))
 	}

--- a/ui/styles.go
+++ b/ui/styles.go
@@ -11,7 +11,7 @@ var (
 	GreenBorder  = BorderStyle.BorderForeground(ColGreen)
 	ChipStyle    = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(ColBlue).Faint(true)
 	ChipInactive = ChipStyle.BorderForeground(ColGray)
-	ChipPublish  = ChipStyle.Background(ColBlue).Faint(false)
+	ChipPublish  = ChipStyle.Background(ColPub).Faint(false)
 	InfoStyle    = lipgloss.NewStyle().Foreground(ColBlue).PaddingLeft(1)
 	ErrorStyle   = lipgloss.NewStyle().Foreground(ColWarn).PaddingLeft(1)
 	ConnStyle    = lipgloss.NewStyle().Foreground(ColGray).PaddingLeft(1)

--- a/view_topics.go
+++ b/view_topics.go
@@ -15,10 +15,10 @@ func (m *model) renderTopicsSection() (string, string, []topics.ChipBound) {
 	for i, t := range m.topics.Items {
 		st := ui.ChipStyle
 		switch {
-		case !t.Subscribed:
-			st = ui.ChipInactive
 		case t.Publish:
 			st = ui.ChipPublish
+		case !t.Subscribed:
+			st = ui.ChipInactive
 		}
 		if i == m.topics.Selected() {
 			st = st.BorderForeground(ui.ColPurple)


### PR DESCRIPTION
## Summary
- give publish-topic chips a distinct background color
- highlight publish chips in topic listings

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890f53972448324b4ec39dfa0501f8f