### PR TITLE
Persist topic publish flag in snapshots

### DIFF
--- a/config_state_test.go
+++ b/config_state_test.go
@@ -81,7 +81,7 @@ func TestSaveLoadState(t *testing.T) {
 
 	data := map[string]connections.ConnectionSnapshot{
 		"p1": {
-			Topics:   []connections.TopicSnapshot{{Title: "foo", Active: true}},
+			Topics:   []connections.TopicSnapshot{{Title: "foo", Subscribed: true, Publish: true}},
 			Payloads: []connections.PayloadSnapshot{{Topic: "foo", Payload: "bar"}},
 		},
 	}

--- a/connections/snapshot.go
+++ b/connections/snapshot.go
@@ -2,8 +2,9 @@ package connections
 
 // TopicSnapshot represents a topic and its subscription state for persistence.
 type TopicSnapshot struct {
-	Title  string `toml:"title"`
-	Active bool   `toml:"active"`
+	Title      string `toml:"title"`
+	Subscribed bool   `toml:"subscribed"`
+	Publish    bool   `toml:"publish"`
 }
 
 // PayloadSnapshot represents a stored payload for persistence.

--- a/topics/snapshot.go
+++ b/topics/snapshot.go
@@ -9,7 +9,7 @@ type TopicSnapshot = connections.TopicSnapshot
 func (c *Component) Snapshot() []connections.TopicSnapshot {
 	out := make([]connections.TopicSnapshot, len(c.Items))
 	for i, t := range c.Items {
-		out[i] = connections.TopicSnapshot{Title: t.Name, Active: t.Subscribed}
+		out[i] = connections.TopicSnapshot{Title: t.Name, Subscribed: t.Subscribed, Publish: t.Publish}
 	}
 	return out
 }
@@ -18,6 +18,6 @@ func (c *Component) Snapshot() []connections.TopicSnapshot {
 func (c *Component) SetSnapshot(ts []connections.TopicSnapshot) {
 	c.Items = make([]Item, len(ts))
 	for i, t := range ts {
-		c.Items[i] = Item{Name: t.Title, Subscribed: t.Active}
+		c.Items[i] = Item{Name: t.Title, Subscribed: t.Subscribed, Publish: t.Publish}
 	}
 }

--- a/topics/snapshot_roundtrip_test.go
+++ b/topics/snapshot_roundtrip_test.go
@@ -1,0 +1,17 @@
+package topics
+
+import "testing"
+
+func TestSnapshotRoundTripPublish(t *testing.T) {
+	c := newTestComponent()
+	c.Items = []Item{{Name: "foo", Subscribed: true, Publish: true}}
+	snap := c.Snapshot()
+	if len(snap) != 1 || !snap[0].Publish {
+		t.Fatalf("publish flag not saved: %#v", snap)
+	}
+	c.Items = nil
+	c.SetSnapshot(snap)
+	if len(c.Items) != 1 || !c.Items[0].Publish {
+		t.Fatalf("publish flag not restored: %#v", c.Items)
+	}
+}


### PR DESCRIPTION
## Summary
- track publish state in `TopicSnapshot`
- include publish flag when snapshotting and restoring topics
- rename snapshot subscription field to `Subscribed`
- test snapshot publish flag round-trip and config persistence

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6890f4e4bfd48324b12bff7f47421ed3