### PR TITLE
payloads: rebuild list on snapshot

### DIFF
--- a/payloads/payloads_snapshot.go
+++ b/payloads/payloads_snapshot.go
@@ -11,9 +11,15 @@ func (p *Component) Snapshot() []Snapshot {
 
 // SetSnapshot replaces the current payloads with the provided snapshot.
 func (p *Component) SetSnapshot(ps []Snapshot) {
-	items := make([]Item, len(ps))
-	for i, item := range ps {
-		items[i] = Item{Topic: item.Topic, Payload: item.Payload}
+	seen := make(map[Item]struct{}, len(ps))
+	items := make([]Item, 0, len(ps))
+	for _, snap := range ps {
+		item := Item{Topic: snap.Topic, Payload: snap.Payload}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		items = append(items, item)
 	}
-	p.items = items
+	p.SetItems(items)
 }


### PR DESCRIPTION
## Summary
- sync payload list and view when restoring a snapshot
- ignore duplicate topic/payload pairs during restore

## Testing
- `go vet ./...` *(fails: undefined: ui.ChipStyle in update_client_helpers_test.go)*
- `go test ./...` *(fails: undefined: ui.ChipStyle in update_client_helpers_test.go)*

------
https://chatgpt.com/codex/tasks/task_e_68910db946948324a46ca620ecdd6073