### PR TITLE
ui: drop faint chip style

### DIFF
--- a/ui/styles.go
+++ b/ui/styles.go
@@ -10,9 +10,9 @@ var (
 	BorderStyle  = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(ColBlue).Padding(0, 1)
 	GreenBorder  = BorderStyle.BorderForeground(ColGreen)
 
-	Chip                = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(ColBlue).Faint(true)
+	Chip                = lipgloss.NewStyle().Padding(0, 1).MarginRight(1).Border(lipgloss.NormalBorder()).BorderForeground(ColBlue)
 	ChipFocused         = Chip.BorderTopForeground(ColPink).BorderLeftForeground(ColPink).Foreground(ColPink)
-	ChipInactive        = Chip.BorderForeground(ColGray)
+	ChipInactive        = Chip.BorderForeground(ColGray).Foreground(ColGray)
 	ChipInactiveFocused = ChipInactive.BorderTopForeground(ColPink).BorderLeftForeground(ColPink).Foreground(ColPink)
 	ChipPublish         = Chip.BorderForeground(ColBlue).Background(ColBlue).Foreground(ColWhite).BorderStyle(lipgloss.InnerHalfBlockBorder())
 	ChipPublishFocused  = ChipPublish.BorderTopForeground(ColPink).BorderLeftForeground(ColPink) //.Background(ColPink)

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -21,7 +21,7 @@ func TestHandleMouseScrollTopics(t *testing.T) {
 	m.layout.topics.height = 2
 	m.viewClient()
 	m.setFocus(idTopics)
-	rowH := lipgloss.Height(ui.ChipStyle.Render("t"))
+	rowH := lipgloss.Height(ui.Chip.Render("t"))
 	_, handled := m.handleMouseScroll(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
 	if !handled {
 		t.Fatalf("expected scroll event handled")


### PR DESCRIPTION
## Summary
- remove Faint from Chip style and specify gray inactive text
- update test to use Chip style

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68910e049a0c8324a7532a7c869a9847