### PR TITLE
Fix topics view list sizing

### DIFF
--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -99,6 +99,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 		m.topics.SetActivePane(0)
 		m.topics.RebuildActiveTopicList()
 		m.topics.SetSelected(0)
+		m.topics.List().SetSize(m.ui.width/2-4, m.ui.height-4)
 		return m.setMode(modeTopics)
 	case "ctrl+p":
 		m.payloads.List().SetSize(m.ui.width-4, m.ui.height-4)

--- a/topics/component.go
+++ b/topics/component.go
@@ -396,6 +396,9 @@ func (c *Component) HandleClick(msg tea.MouseMsg, vpOffset int) tea.Cmd {
 	return nil
 }
 
+// List exposes the topics list model.
+func (c *Component) List() *list.Model { return &c.list }
+
 func (c *Component) SetSelected(i int) {
 	c.selected = i
 	if i < 0 || i >= len(c.Items) {

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -22,6 +22,7 @@ func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
 	}
 	m.traces.ViewList().SetSize(msg.Width-4, m.layout.trace.height)
 	m.traces.List().SetSize(msg.Width-4, msg.Height-4)
+	m.topics.List().SetSize(msg.Width/2-4, msg.Height-4)
 	m.help.SetSize(msg.Width, msg.Height)
 	m.history.Detail().Width = msg.Width - 4
 	m.history.Detail().Height = msg.Height - 4


### PR DESCRIPTION
## Summary
- expose topics list model for layout control
- size topics list on window resize and when entering topics view

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689115a1049c8324ae15be74b7e06200