### PR TITLE
Fix topics view list sizing

### DIFF
--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -99,6 +99,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 		m.topics.SetActivePane(0)
 		m.topics.RebuildActiveTopicList()
 		m.topics.SetSelected(0)
+		m.topics.List().SetSize(m.ui.width/2-4, m.ui.height-4)
 		return m.setMode(modeTopics)
 	case "ctrl+p":
 		m.payloads.List().SetSize(m.ui.width-4, m.ui.height-4)

--- a/model_base.go
+++ b/model_base.go
@@ -8,15 +8,15 @@ import (
 )
 
 const (
-	idTopics         = "topics"          // topics chip list
-	idTopic          = "topic"           // topic input box
-	idMessage        = message.ID        // message input box
-	idHistory        = "history"         // history list
-	idConnList       = "conn-list"       // broker list
-	idTopicsEnabled  = "topics-enabled"  // enabled topics pane
-	idTopicsDisabled = "topics-disabled" // disabled topics pane
-	idPayloadList    = payloads.IDList   // payload manager list
-	idHelp           = help.ID           // help icon
+	idTopics             = "topics"              // topics chip list
+	idTopic              = "topic"               // topic input box
+	idMessage            = message.ID            // message input box
+	idHistory            = "history"             // history list
+	idConnList           = "conn-list"           // broker list
+	idTopicsSubscribed   = "topics-subscribed"   // subscribed topics pane
+	idTopicsUnsubscribed = "topics-unsubscribed" // unsubscribed topics pane
+	idPayloadList        = payloads.IDList       // payload manager list
+	idHelp               = help.ID               // help icon
 )
 
 type appMode int
@@ -42,7 +42,7 @@ var focusByMode = map[appMode][]string{
 	modeConnections:    {idConnList, idHelp},
 	modeEditConnection: {idConnList, idHelp},
 	modeConfirmDelete:  {},
-	modeTopics:         {idTopicsEnabled, idTopicsDisabled, idHelp},
+	modeTopics:         {idTopicsSubscribed, idTopicsUnsubscribed, idHelp},
 	modePayloads:       {idPayloadList, idHelp},
 	modeTracer:         {traces.IDList, idHelp},
 	modeEditTrace:      {idHelp},

--- a/topics/component.go
+++ b/topics/component.go
@@ -65,11 +65,11 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 			return c.api.ShowClient()
 		case "left":
 			if c.panes.active == 1 {
-				fcmd = c.api.SetFocus(idTopicsEnabled)
+				fcmd = c.api.SetFocus(idTopicsSubscribed)
 			}
 		case "right":
 			if c.panes.active == 0 {
-				fcmd = c.api.SetFocus(idTopicsDisabled)
+				fcmd = c.api.SetFocus(idTopicsUnsubscribed)
 			}
 		case "delete":
 			i := c.selected
@@ -110,8 +110,8 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 // View displays the topic manager list.
 func (c *Component) View() string {
 	c.api.ResetElemPos()
-	c.api.SetElemPos(idTopicsEnabled, 1)
-	c.api.SetElemPos(idTopicsDisabled, 1)
+	c.api.SetElemPos(idTopicsSubscribed, 1)
+	c.api.SetElemPos(idTopicsUnsubscribed, 1)
 	help := ui.InfoStyle.Render("[space] toggle  [p] publish  [del] delete  [esc] back")
 	activeView := c.list.View()
 	var left, right string
@@ -121,16 +121,16 @@ func (c *Component) View() string {
 		other.SetShowTitle(false)
 		other.Paginator.Page = c.panes.unsubscribed.page
 		other.Select(c.panes.unsubscribed.sel)
-		left = ui.LegendBox(activeView, "Enabled", c.api.Width()/2-2, 0, ui.ColBlue, c.api.FocusedID() == idTopicsEnabled, -1)
-		right = ui.LegendBox(other.View(), "Disabled", c.api.Width()/2-2, 0, ui.ColBlue, false, -1)
+		left = ui.LegendBox(activeView, "Subscribed", c.api.Width()/2-2, 0, ui.ColBlue, c.api.FocusedID() == idTopicsSubscribed, -1)
+		right = ui.LegendBox(other.View(), "Unsubscribed", c.api.Width()/2-2, 0, ui.ColBlue, false, -1)
 	} else {
 		other := list.New(c.SubscribedItems(), list.NewDefaultDelegate(), c.list.Width(), c.list.Height())
 		other.DisableQuitKeybindings()
 		other.SetShowTitle(false)
 		other.Paginator.Page = c.panes.subscribed.page
 		other.Select(c.panes.subscribed.sel)
-		left = ui.LegendBox(other.View(), "Enabled", c.api.Width()/2-2, 0, ui.ColBlue, false, -1)
-		right = ui.LegendBox(activeView, "Disabled", c.api.Width()/2-2, 0, ui.ColBlue, c.api.FocusedID() == idTopicsDisabled, -1)
+		left = ui.LegendBox(other.View(), "Subscribed", c.api.Width()/2-2, 0, ui.ColBlue, false, -1)
+		right = ui.LegendBox(activeView, "Unsubscribed", c.api.Width()/2-2, 0, ui.ColBlue, c.api.FocusedID() == idTopicsUnsubscribed, -1)
 	}
 	panes := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
 	content := lipgloss.JoinVertical(lipgloss.Left, panes, help)
@@ -151,9 +151,9 @@ func (c *Component) UpdateInput(msg tea.Msg) tea.Cmd {
 // Focusables exposes focusable elements for the topics component.
 func (c *Component) Focusables() map[string]focus.Focusable {
 	return map[string]focus.Focusable{
-		idTopicsEnabled:  &c.panes.subscribed,
-		idTopicsDisabled: &c.panes.unsubscribed,
-		idTopic:          focus.Adapt(&c.Input),
+		idTopicsSubscribed:   &c.panes.subscribed,
+		idTopicsUnsubscribed: &c.panes.unsubscribed,
+		idTopic:              focus.Adapt(&c.Input),
 	}
 }
 
@@ -395,6 +395,9 @@ func (c *Component) HandleClick(msg tea.MouseMsg, vpOffset int) tea.Cmd {
 	}
 	return nil
 }
+
+// List exposes the topics list model.
+func (c *Component) List() *list.Model { return &c.list }
 
 func (c *Component) SetSelected(i int) {
 	c.selected = i

--- a/topics/types.go
+++ b/topics/types.go
@@ -1,9 +1,9 @@
 package topics
 
 const (
-	idTopicsEnabled  = "topics-enabled"
-	idTopicsDisabled = "topics-disabled"
-	idTopic          = "topic"
+	idTopicsSubscribed   = "topics-subscribed"
+	idTopicsUnsubscribed = "topics-unsubscribed"
+	idTopic              = "topic"
 )
 
 // Item represents a topic with subscription and publish state.

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -22,6 +22,7 @@ func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
 	}
 	m.traces.ViewList().SetSize(msg.Width-4, m.layout.trace.height)
 	m.traces.List().SetSize(msg.Width-4, msg.Height-4)
+	m.topics.List().SetSize(msg.Width/2-4, msg.Height-4)
 	m.help.SetSize(msg.Width, msg.Height)
 	m.history.Detail().Width = msg.Width - 4
 	m.history.Detail().Height = msg.Height - 4

--- a/view_topics.go
+++ b/view_topics.go
@@ -15,7 +15,7 @@ func (m *model) renderTopicsSection() (string, string, []topics.ChipBound) {
 	for i, t := range m.topics.Items {
 		st := ui.ChipInactive
 		switch {
-		case t.Publish:
+		case t.Publish && t.Subscribed:
 			st = ui.ChipPublish
 			if i == m.topics.Selected() {
 				st = ui.ChipPublishFocused
@@ -25,7 +25,6 @@ func (m *model) renderTopicsSection() (string, string, []topics.ChipBound) {
 			if i == m.topics.Selected() {
 				st = ui.ChipFocused
 			}
-
 		default:
 			if i == m.topics.Selected() {
 				st = ui.ChipInactiveFocused


### PR DESCRIPTION
## Summary
- expose topics list model for layout control
- size topics list on window resize and when entering topics view
- rename topic panes to subscribed/unsubscribed
- show inactive chips for published but unsubscribed topics

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689115a1049c8324ae15be74b7e06200