### PR TITLE
Show topic state legend in topics box

### DIFF
--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -77,7 +77,7 @@ func TestHistoryFilterUpdatesCounts(t *testing.T) {
 	m.history.FilterForm().Start().SetValue("")
 	m.history.FilterForm().End().SetValue("")
 	m.history.UpdateFilter(tea.KeyMsg{Type: tea.KeyEnter})
-	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
+	m.Update(tea.WindowSizeMsg{Width: 40, Height: 24})
 
 	view := m.viewClient()
 	if !strings.Contains(view, "History (1/2 messages") {

--- a/view_client.go
+++ b/view_client.go
@@ -56,10 +56,9 @@ func (m *model) viewClient() string {
 	box := lipgloss.NewStyle().Width(m.ui.width).Padding(0, 1, 1, 1).Render(content)
 	m.ui.viewport.SetContent(box)
 	m.ui.viewport.Width = m.ui.width
-	// Deduct two lines for the info header and one for the footer note.
-	m.ui.viewport.Height = m.ui.height - 3
+	// Deduct two lines for the info header.
+	m.ui.viewport.Height = m.ui.height - 2
 
 	view := m.ui.viewport.View()
-	publishNote := ui.ConnStyle.Copy().Foreground(ui.ColDarkGray).Render("Topics with blue background will be published")
-	return m.overlayHelp(lipgloss.JoinVertical(lipgloss.Left, infoLine, view, publishNote))
+	return m.overlayHelp(lipgloss.JoinVertical(lipgloss.Left, infoLine, view))
 }

--- a/view_topics.go
+++ b/view_topics.go
@@ -54,6 +54,10 @@ func (m *model) renderTopicsSection() (string, string, []topics.ChipBound) {
 		topicsSP = m.topics.VP.ScrollPercent()
 	}
 	chipContent := m.topics.VP.View()
+	stateInfo := ui.InfoStyle.Render("blue=sub  fill=pub  gray=off  pink=sel")
+	keyInfo := ui.InfoStyle.Render("[←/→] move  [enter] toggle  [p] pub  [del] del")
+	chipContent = lipgloss.JoinVertical(lipgloss.Left, chipContent, stateInfo, keyInfo)
+	infoHeight := 2
 	visible := []topics.ChipBound{}
 	for _, b := range bounds {
 		if b.YPos >= startLine && b.YPos < endLine {
@@ -71,7 +75,11 @@ func (m *model) renderTopicsSection() (string, string, []topics.ChipBound) {
 	}
 	label := fmt.Sprintf("Topics %d/%d", active, len(m.topics.Items))
 	topicsFocused := m.ui.focusOrder[m.ui.focusIndex] == idTopics
-	topicsBox := ui.LegendBox(chipContent, label, m.ui.width-2, topicsBoxHeight, ui.ColBlue, topicsFocused, topicsSP)
+	scroll := topicsSP
+	if scroll >= 0 {
+		scroll = scroll * float64(topicsBoxHeight-1) / float64(topicsBoxHeight+infoHeight-1)
+	}
+	topicsBox := ui.LegendBox(chipContent, label, m.ui.width-2, topicsBoxHeight+infoHeight, ui.ColBlue, topicsFocused, scroll)
 
 	topicFocused := m.ui.focusOrder[m.ui.focusIndex] == idTopic
 	topicBox := ui.LegendBox(m.topics.Input.View(), "Topic", m.ui.width-2, 0, ui.ColBlue, topicFocused, -1)


### PR DESCRIPTION
## Summary
- add legend explaining topic chip states and shortcuts
- remove obsolete footer note and adjust viewport height
- update history filter test for taller layout

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68911f2a9db883248e3e5fa5197a5f7a