### PR TITLE
Check trace setup errors

### DIFF
--- a/run.go
+++ b/run.go
@@ -59,16 +59,30 @@ func Main() {
 		}
 		var start, end time.Time
 		if traceStart != "" {
-			start, _ = time.Parse(time.RFC3339, traceStart)
+			var err error
+			start, err = time.Parse(time.RFC3339, traceStart)
+			if err != nil {
+				log.Println("invalid trace start time:", err)
+				return
+			}
 		}
 		if traceEnd != "" {
-			end, _ = time.Parse(time.RFC3339, traceEnd)
+			var err error
+			end, err = time.Parse(time.RFC3339, traceEnd)
+			if err != nil {
+				log.Println("invalid trace end time:", err)
+				return
+			}
 			if end.Before(time.Now()) {
 				log.Println("trace end time already passed")
 				return
 			}
 		}
-		exists, _ := traces.FileStore{}.HasData(profileName, traceKey)
+		exists, err := traces.FileStore{}.HasData(profileName, traceKey)
+		if err != nil {
+			log.Println("trace data check failed:", err)
+			return
+		}
 		if exists {
 			log.Println("trace key already exists")
 			return


### PR DESCRIPTION
## Summary
- validate trace start and end time strings
- check trace data store for errors

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ac3f31688324b0c2c78b1786edf4