### PR TITLE
Add option to skip TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ password = "keyring:emqutiti-local/user"
 Tips:
 - More options like TLS and session settings are available; see the `config` package for details.
 - Set `random_id_suffix = true` for unique client IDs.
-- Enable **Load from env** to read variables such as `EMQUTITI_LOCAL_BROKER_PASSWORD`.
+- Set `skip_tls_verify = true` to bypass TLS certificate checks (useful for self-signed brokers).
+- Enable **Load from env** to read variables such as `EMQUTITI_LOCAL_SKIP_TLS_VERIFY` or `EMQUTITI_LOCAL_BROKER_PASSWORD`.
 
 - Set `EMQUTITI_DEFAULT_PASSWORD` to override profile passwords when not loading from env.
 - Set `default_profile` to auto-connect on launch. Use `Ctrl+O` in the broker manager to toggle it.

--- a/connections/form.go
+++ b/connections/form.go
@@ -45,6 +45,7 @@ var formFields = []fieldDef{
 	{key: "Password", label: "Password", fieldType: ftPassword},
 	{key: "FromEnv", label: "Load from env", placeholder: "Values from env", fieldType: ftBool},
 	{key: "SSL", label: "SSL/TLS", placeholder: "SSL/TLS", fieldType: ftBool},
+	{key: "SkipTLSVerify", label: "Skip TLS verify", placeholder: "Skip TLS verify", fieldType: ftBool},
 	{key: "MQTTVersion", label: "MQTT Version", placeholder: "MQTT Version", fieldType: ftSelect, options: []string{"3", "4", "5"}},
 	{key: "ConnectTimeout", label: "Connect Timeout (s)", placeholder: "Connect Timeout (s)", fieldType: ftText},
 	{key: "KeepAlive", label: "Keep Alive (s)", placeholder: "Keep Alive (s)", fieldType: ftText},

--- a/connections/profile.go
+++ b/connections/profile.go
@@ -18,6 +18,7 @@ type Profile struct {
 	Password            string `toml:"password" env:"password"`
 	FromEnv             bool   `toml:"from_env"`
 	SSL                 bool   `toml:"ssl_tls" env:"ssl_tls"`
+	SkipTLSVerify       bool   `toml:"skip_tls_verify" env:"skip_tls_verify"`
 	MQTTVersion         string `toml:"mqtt_version" env:"mqtt_version"`
 	ConnectTimeout      int    `toml:"connect_timeout" env:"connect_timeout"`
 	KeepAlive           int    `toml:"keep_alive" env:"keep_alive"`

--- a/connections/profile_env.go
+++ b/connections/profile_env.go
@@ -42,6 +42,11 @@ var profileEnvSetters = map[string]profileEnvSetter{
 			p.SSL = bv
 		}
 	},
+	"skip_tls_verify": func(p *Profile, v string) {
+		if bv, err := strconv.ParseBool(v); err == nil {
+			p.SkipTLSVerify = bv
+		}
+	},
 	"mqtt_version": func(p *Profile, v string) { p.MQTTVersion = v },
 	"connect_timeout": func(p *Profile, v string) {
 		if iv, err := strconv.Atoi(v); err == nil {

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -63,7 +63,7 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 	}
 
 	if p.SSL {
-		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: p.SkipTLSVerify})
 	}
 	opts.OnConnect = func(client mqtt.Client) {
 		log.Println("Connected to MQTT broker")

--- a/mqttclient_tls_test.go
+++ b/mqttclient_tls_test.go
@@ -1,0 +1,96 @@
+package emqutiti
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	connections "github.com/marang/emqutiti/connections"
+)
+
+// startTLSServer starts a minimal TLS server that speaks enough MQTT to accept a connection.
+func startTLSServer(t *testing.T) (addr string, closeFn func()) {
+	t.Helper()
+	cert, key := generateCert(t)
+	tlsCert, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		t.Fatalf("x509 key pair: %v", err)
+	}
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{tlsCert}})
+	if err != nil {
+		t.Fatalf("tls listen: %v", err)
+	}
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Read some of the CONNECT packet then respond with CONNACK success.
+		buf := make([]byte, 1024)
+		conn.Read(buf)
+		conn.Write([]byte{0x20, 0x02, 0x00, 0x00})
+		time.Sleep(100 * time.Millisecond)
+	}()
+	return ln.Addr().String(), func() { ln.Close() }
+}
+
+func generateCert(t *testing.T) (certPEM, keyPEM []byte) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		DNSNames:              []string{"127.0.0.1"},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM = pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	return
+}
+
+func TestNewMQTTClientTLSSkipVerify(t *testing.T) {
+	addr, closeFn := startTLSServer(t)
+	defer closeFn()
+	host, portStr, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+	p := connections.Profile{Schema: "ssl", Host: host, Port: port, SSL: true, SkipTLSVerify: true, ClientID: "cid"}
+	c, err := NewMQTTClient(p, nil)
+	if err != nil {
+		t.Fatalf("NewMQTTClient: %v", err)
+	}
+	defer c.Disconnect()
+	or := c.Client.OptionsReader()
+	if !or.TLSConfig().InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify true")
+	}
+}
+
+func TestNewMQTTClientTLSSecure(t *testing.T) {
+	addr, closeFn := startTLSServer(t)
+	defer closeFn()
+	host, portStr, _ := net.SplitHostPort(addr)
+	port, _ := strconv.Atoi(portStr)
+	p := connections.Profile{Schema: "ssl", Host: host, Port: port, SSL: true, ClientID: "cid"}
+	if _, err := NewMQTTClient(p, nil); err == nil || !strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("expected cert error, got %v", err)
+	}
+}

--- a/traces/headless.go
+++ b/traces/headless.go
@@ -54,7 +54,7 @@ func newMQTTClient(p connections.Profile) (*mqttClient, error) {
 		opts.SetWill(p.LastWillTopic, p.LastWillPayload, byte(p.LastWillQos), p.LastWillRetain)
 	}
 	if p.SSL {
-		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: true})
+		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: p.SkipTLSVerify})
 	}
 	client := mqtt.NewClient(opts)
 	if token := client.Connect(); token.Wait() && token.Error() != nil {


### PR DESCRIPTION
## Summary
- allow profiles to disable TLS certificate checking via `SkipTLSVerify`
- wire skip verification through forms, env vars and docs
- respect the setting in clients and tracer
- cover secure and insecure TLS modes in tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ac4aee7483249322770cf12a9964