### PR TITLE
Handle marshal errors in tracer storage

### DIFF
--- a/traces/runtime.go
+++ b/traces/runtime.go
@@ -98,7 +98,10 @@ func (t *Tracer) Start() error {
 				if ts.Before(t.cfg.Start) {
 					return
 				}
-				tracerAdd(t.cfg.Profile, t.cfg.Key, TracerMessage{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"})
+				if err := tracerAdd(t.cfg.Profile, t.cfg.Key, TracerMessage{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"}); err != nil {
+					fmt.Printf("tracerAdd: %v\n", err)
+					return
+				}
 				t.mu.Lock()
 				for _, sub := range t.cfg.Topics {
 					if tracerMatch(sub, m.Topic()) {

--- a/traces/store.go
+++ b/traces/store.go
@@ -10,6 +10,8 @@ import (
 	"github.com/marang/emqutiti/internal/files"
 )
 
+var jsonMarshal = json.Marshal
+
 // openTracerStore opens the trace database for the profile.
 // When readonly is true, the database is opened in read-only mode.
 func openTracerStore(profile string, readonly bool) (*badger.DB, error) {
@@ -36,7 +38,10 @@ func tracerAdd(profile, key string, msg TracerMessage) error {
 	defer db.Close()
 
 	dbKey := []byte(fmt.Sprintf("trace/%s/%s/%020d", key, msg.Topic, msg.Timestamp.UnixNano()))
-	val, _ := json.Marshal(msg)
+	val, err := jsonMarshal(msg)
+	if err != nil {
+		return err
+	}
 	return db.Update(func(txn *badger.Txn) error {
 		return txn.Set(dbKey, val)
 	})

--- a/traces/store_test.go
+++ b/traces/store_test.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"errors"
 	"testing"
 	"time"
 )
@@ -33,5 +34,19 @@ func TestHasDataAndClear(t *testing.T) {
 	has, err = tracerHasData("test", "k1")
 	if err != nil || has {
 		t.Fatalf("expected no data")
+	}
+}
+
+func TestTracerAddError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	old := jsonMarshal
+	jsonMarshal = func(any) ([]byte, error) { return nil, errors.New("fail") }
+	defer func() { jsonMarshal = old }()
+
+	err := tracerAdd("test", "k1", TracerMessage{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }


### PR DESCRIPTION
## Summary
- return an error from tracerAdd when JSON marshalling fails
- log tracerAdd failures in the runtime subscriber
- add a test that simulates a marshalling failure

## Testing
- `go vet ./...` *(failed: terminated after hanging)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ac56036c832484f012829ca1f920