### PR TITLE
Handle invalid trace timestamps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Summarize changes and test results in pull request descriptions.
 - Keep documentation snappy. Use bullet lists and short sections so the README
   is easy to skim. Mention the main keyboard shortcuts.
+- Favor idiomatic Go patterns and avoid redundant code.
 
 ## Agent Notes
 The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter` when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name. The importer code lives in the main package and runs via these flags.

--- a/traces/state_test.go
+++ b/traces/state_test.go
@@ -1,6 +1,8 @@
 package traces
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,5 +39,48 @@ func TestSaveTracesPreservesExistingConfig(t *testing.T) {
 	}
 	if !strings.Contains(s, "[traces]") {
 		t.Fatalf("missing traces section: %s", s)
+	}
+}
+
+func TestLoadTracesInvalidTimes(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfgPath, err := connections.DefaultUserConfigFile()
+	if err != nil {
+		t.Fatalf("cfg path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := `[traces]
+  [traces.t1]
+  profile = "p1"
+  start = "bad"
+  [traces.t2]
+  profile = "p2"
+  end = "also-bad"
+`
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	defer log.SetOutput(os.Stderr)
+	traces := loadTraces()
+	if _, ok := traces["t1"]; !ok {
+		t.Fatalf("missing t1 trace")
+	}
+	if _, ok := traces["t2"]; !ok {
+		t.Fatalf("missing t2 trace")
+	}
+	if !traces["t1"].Start.IsZero() {
+		t.Fatalf("expected zero start time")
+	}
+	if !traces["t2"].End.IsZero() {
+		t.Fatalf("expected zero end time")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "invalid start time") || !strings.Contains(out, "invalid end time") {
+		t.Fatalf("expected log messages, got: %s", out)
 	}
 }


### PR DESCRIPTION
## Summary
- log parse errors for trace start and end times
- add tests for malformed RFC3339 timestamps
- refactor trace loading for idiomatic Go and update repo guidelines

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ac8020ac83248439c6a1d64f6512