### PR TITLE
Add profile index guard helper

### DIFF
--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -38,18 +38,22 @@ func (m *model) SubscribeActiveTopics() {
 func (m *model) ConnectionMessage() string       { return m.connections.Connection }
 func (m *model) SetConnectionMessage(msg string) { m.connections.Connection = msg }
 func (m *model) Active() string                  { return m.connections.Active }
+
+func (m *model) validProfileIndex(idx int) bool {
+	return idx >= 0 && idx < len(m.connections.Manager.Profiles)
+}
 func (m *model) BeginAdd() {
 	f := connections.NewForm(connections.Profile{}, -1)
 	m.connections.Form = &f
 }
 func (m *model) BeginEdit(index int) {
-	if index >= 0 && index < len(m.connections.Manager.Profiles) {
+	if m.validProfileIndex(index) {
 		f := connections.NewForm(m.connections.Manager.Profiles[index], index)
 		m.connections.Form = &f
 	}
 }
 func (m *model) BeginDelete(index int) {
-	if index < 0 || index >= len(m.connections.Manager.Profiles) {
+	if !m.validProfileIndex(index) {
 		return
 	}
 	name := m.connections.Manager.Profiles[index].Name


### PR DESCRIPTION
## Summary
- add `validProfileIndex` helper for connection profile bounds checks
- use helper in `BeginEdit` and `BeginDelete`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891c122d27083248766de047db08049