### PR TITLE
Export model helpers

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -106,5 +106,5 @@ func (m *model) handleHistoryViewKey() tea.Cmd {
 	m.history.SetDetailItem(hi)
 	m.history.Detail().SetContent(hi.Payload)
 	m.history.Detail().SetYOffset(0)
-	return m.setMode(modeHistoryDetail)
+	return m.SetMode(modeHistoryDetail)
 }

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -115,8 +115,8 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 		}
 	}
 	m.history.SetItems(hitems)
-	rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
-	m.startConfirm("Delete selected messages? [y/n]", "", rf, func() tea.Cmd {
+	rf := func() tea.Cmd { return m.SetFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+	m.StartConfirm("Delete selected messages? [y/n]", "", rf, func() tea.Cmd {
 		hitems := m.history.Items()
 		for i := len(hitems) - 1; i >= 0; i-- {
 			it := hitems[i]

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -10,7 +10,7 @@ func (m *model) handleTabKey() tea.Cmd {
 		m.focus.Next()
 		m.ui.focusIndex = m.focus.Index()
 		id := m.ui.focusOrder[m.ui.focusIndex]
-		m.setFocus(id)
+		m.SetFocus(id)
 		if id == idTopics {
 			if len(m.topics.Items) > 0 {
 				sel := m.topics.Selected()
@@ -32,7 +32,7 @@ func (m *model) handleShiftTabKey() tea.Cmd {
 		m.focus.Prev()
 		m.ui.focusIndex = m.focus.Index()
 		id := m.ui.focusOrder[m.ui.focusIndex]
-		m.setFocus(id)
+		m.SetFocus(id)
 		if id == idTopics {
 			if len(m.topics.Items) > 0 {
 				sel := m.topics.Selected()
@@ -94,19 +94,19 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 		m.connections.RefreshConnectionItems()
 		m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
 		m.traces.SavePlannedTraces()
-		return m.setMode(modeConnections)
+		return m.SetMode(modeConnections)
 	case "ctrl+t":
 		m.topics.SetActivePane(0)
 		m.topics.RebuildActiveTopicList()
 		m.topics.SetSelected(0)
 		m.topics.List().SetSize(m.ui.width/2-4, m.ui.height-4)
-		return m.setMode(modeTopics)
+		return m.SetMode(modeTopics)
 	case "ctrl+p":
 		m.payloads.List().SetSize(m.ui.width-4, m.ui.height-4)
-		return m.setMode(modePayloads)
+		return m.SetMode(modePayloads)
 	case "ctrl+r":
 		m.traces.List().SetSize(m.ui.width-4, m.ui.height-4)
-		return m.setMode(modeTracer)
+		return m.SetMode(modeTracer)
 	default:
 		return nil
 	}

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -47,7 +47,7 @@ func (m *model) handleEnterKey() tea.Cmd {
 		if topic != "" && !m.topics.HasTopic(topic) {
 			m.topics.Items = append(m.topics.Items, topics.Item{Name: topic, Subscribed: true})
 			m.topics.SortTopics()
-			if m.currentMode() == modeTopics {
+			if m.CurrentMode() == modeTopics {
 				m.topics.RebuildActiveTopicList()
 			}
 			m.topics.Input.SetValue("")
@@ -70,10 +70,10 @@ func (m *model) handleEnterKey() tea.Cmd {
 func (m *model) handleDeleteTopicKey() tea.Cmd {
 	idx := m.topics.Selected()
 	name := m.topics.Items[idx].Name
-	rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
-	m.startConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
+	rf := func() tea.Cmd { return m.SetFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+	m.StartConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
 		cmd := m.topics.RemoveTopic(idx)
-		if m.currentMode() == modeTopics {
+		if m.CurrentMode() == modeTopics {
 			m.topics.RebuildActiveTopicList()
 		}
 		return cmd

--- a/client_publish_test.go
+++ b/client_publish_test.go
@@ -14,7 +14,7 @@ func TestHandlePublishKeyFlags(t *testing.T) {
 		{Name: "c", Publish: true},
 	}
 	m.message.SetPayload("hello")
-	m.setFocus(idMessage)
+	m.SetFocus(idMessage)
 	m.handlePublishKey()
 	items := m.payloads.Items()
 	if len(items) != 2 {
@@ -33,7 +33,7 @@ func TestHandlePublishKeyFallback(t *testing.T) {
 	}
 	m.topics.SetSelected(1)
 	m.message.SetPayload("hi")
-	m.setFocus(idMessage)
+	m.SetFocus(idMessage)
 	m.handlePublishKey()
 	items := m.payloads.Items()
 	if len(items) != 1 {

--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -54,8 +54,8 @@ func (m *model) BeginDelete(index int) {
 	}
 	name := m.connections.Manager.Profiles[index].Name
 	info := "This also deletes history and traces"
-	rf := func() tea.Cmd { return m.setFocus(m.ui.focusOrder[m.ui.focusIndex]) }
-	m.startConfirm(
+	rf := func() tea.Cmd { return m.SetFocus(m.ui.focusOrder[m.ui.focusIndex]) }
+	m.StartConfirm(
 		fmt.Sprintf("Delete broker '%s'? [y/n]", name),
 		info,
 		rf,

--- a/focus.go
+++ b/focus.go
@@ -2,8 +2,8 @@ package emqutiti
 
 import tea "github.com/charmbracelet/bubbletea"
 
-// setFocus moves focus to the given element id.
-func (m *model) setFocus(id string) tea.Cmd {
+// SetFocus moves focus to the given element id.
+func (m *model) SetFocus(id string) tea.Cmd {
 	for i, name := range m.ui.focusOrder {
 		if name == id {
 			m.focus.Set(i)
@@ -11,7 +11,7 @@ func (m *model) setFocus(id string) tea.Cmd {
 			break
 		}
 	}
-	m.scrollToFocused()
+	m.ScrollToFocused()
 	return nil
 }
 
@@ -28,18 +28,18 @@ func (m *model) focusFromMouse(y int) tea.Cmd {
 	}
 	if chosen != "" {
 		if chosen != m.ui.focusOrder[m.ui.focusIndex] {
-			return m.setFocus(chosen)
+			return m.SetFocus(chosen)
 		}
 		return nil
 	}
 	if len(m.ui.focusOrder) > 0 && m.ui.focusOrder[m.ui.focusIndex] != m.ui.focusOrder[0] {
-		return m.setFocus(m.ui.focusOrder[0])
+		return m.SetFocus(m.ui.focusOrder[0])
 	}
 	return nil
 }
 
-// scrollToFocused ensures the focused element is visible in the viewport.
-func (m *model) scrollToFocused() {
+// ScrollToFocused ensures the focused element is visible in the viewport.
+func (m *model) ScrollToFocused() {
 	if len(m.ui.focusOrder) == 0 {
 		return
 	}

--- a/focus_test.go
+++ b/focus_test.go
@@ -2,15 +2,15 @@ package emqutiti
 
 import "testing"
 
-// Test that setFocus correctly focuses the message input
+// Test that SetFocus correctly focuses the message input
 func TestSetFocusMessage(t *testing.T) {
 	m, _ := initialModel(nil)
 	if m.message.Input().Focused() {
 		t.Fatalf("message input should start blurred")
 	}
-	m.setFocus(idMessage)
+	m.SetFocus(idMessage)
 	if !m.message.Input().Focused() {
-		t.Fatalf("message input not focused after setFocus")
+		t.Fatalf("message input not focused after SetFocus")
 	}
 	if m.focus.Index() != 2 {
 		t.Fatalf("focusIndex expected 2, got %d", m.focus.Index())

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -32,25 +32,14 @@ func (m *model) FocusedID() string { return m.ui.focusOrder[m.ui.focusIndex] }
 // ListenStatus proxies connection status updates for components.
 func (m *model) ListenStatus() tea.Cmd { return m.connections.ListenStatus() }
 
-// ScrollToFocused ensures the focused element is visible.
-func (m *model) ScrollToFocused() { m.scrollToFocused() }
-
 // ResetElemPos clears cached element positions.
 func (m *model) ResetElemPos() { m.ui.elemPos = map[string]int{} }
 
 // SetElemPos records the position of a UI element.
 func (m *model) SetElemPos(id string, pos int) { m.ui.elemPos[id] = pos }
 
-// SetFocus delegates focus changes to the model's focus manager.
-func (m *model) SetFocus(id string) tea.Cmd { return m.setFocus(id) }
-
 // StartConfirm displays a confirmation dialog and runs the action on accept.
 func (m *model) StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
-	m.startConfirm(prompt, info, returnFocus, action, cancel)
-}
-
-// startConfirm displays a confirmation dialog and runs the action on accept.
-func (m *model) startConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
 	m.confirm = confirm.NewComponent(m, m, returnFocus, action, cancel)
 	m.confirm.Start(prompt, info)
 	m.components[modeConfirmDelete] = m.confirm
@@ -76,11 +65,11 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	}
 	hf := history.NewFilterForm(topics, topic, payload, start, end, m.history.ShowArchived())
 	m.history.SetFilterForm(&hf)
-	return m.setMode(modeHistoryFilter)
+	return m.SetMode(modeHistoryFilter)
 }
 
-// setMode updates the current mode and focus order.
-func (m *model) setMode(mode appMode) tea.Cmd {
+// SetMode updates the current mode and focus order.
+func (m *model) SetMode(mode appMode) tea.Cmd {
 	if m.focus != nil && len(m.ui.focusOrder) > m.ui.focusIndex {
 		if f, ok := m.focusables[m.ui.focusOrder[m.ui.focusIndex]]; ok {
 			f.Blur()
@@ -122,36 +111,27 @@ func (m *model) setMode(mode appMode) tea.Cmd {
 	return nil
 }
 
-// currentMode returns the active application mode.
-func (m *model) currentMode() appMode {
+// CurrentMode returns the active application mode.
+func (m *model) CurrentMode() appMode {
 	if len(m.ui.modeStack) == 0 {
 		return modeClient
 	}
 	return m.ui.modeStack[0]
 }
 
-// previousMode returns the last mode before the current one.
-func (m *model) previousMode() appMode {
+// PreviousMode returns the last mode before the current one.
+func (m *model) PreviousMode() appMode {
 	if len(m.ui.modeStack) > 1 {
 		return m.ui.modeStack[1]
 	}
-	return m.currentMode()
+	return m.CurrentMode()
 }
 
-// SetMode exposes setMode to satisfy the navigator interface.
-func (m *model) SetMode(mode appMode) tea.Cmd { return m.setMode(mode) }
-
-// PreviousMode exposes previousMode to satisfy the navigator interface.
-func (m *model) PreviousMode() appMode { return m.previousMode() }
-
 // SetConfirmMode switches to the confirmation screen.
-func (m *model) SetConfirmMode() tea.Cmd { return m.setMode(modeConfirmDelete) }
+func (m *model) SetConfirmMode() tea.Cmd { return m.SetMode(modeConfirmDelete) }
 
 // SetPreviousMode returns to the prior screen.
-func (m *model) SetPreviousMode() tea.Cmd { return m.setMode(m.previousMode()) }
-
-// CurrentMode exposes currentMode to satisfy component interfaces.
-func (m *model) CurrentMode() appMode { return m.currentMode() }
+func (m *model) SetPreviousMode() tea.Cmd { return m.SetMode(m.PreviousMode()) }
 
 // Width returns the current UI width.
 func (m *model) Width() int { return m.ui.width }
@@ -163,4 +143,4 @@ func (m *model) MessageHeight() int { return m.layout.message.height }
 func (m *model) Height() int { return m.ui.height }
 
 // SetClientMode switches to the main client screen.
-func (m *model) SetClientMode() tea.Cmd { return m.setMode(modeClient) }
+func (m *model) SetClientMode() tea.Cmd { return m.SetMode(modeClient) }

--- a/model_history.go
+++ b/model_history.go
@@ -20,12 +20,12 @@ type historyModelAdapter struct{ *model }
 
 func (a historyModelAdapter) SetMode(mode history.Mode) tea.Cmd {
 	if am, ok := mode.(appMode); ok {
-		return a.model.setMode(am)
+		return a.model.SetMode(am)
 	}
 	return nil
 }
-func (a historyModelAdapter) PreviousMode() history.Mode  { return a.model.previousMode() }
-func (a historyModelAdapter) CurrentMode() history.Mode   { return a.model.currentMode() }
+func (a historyModelAdapter) PreviousMode() history.Mode  { return a.model.PreviousMode() }
+func (a historyModelAdapter) CurrentMode() history.Mode   { return a.model.CurrentMode() }
 func (a historyModelAdapter) SetFocus(id string) tea.Cmd  { return a.model.SetFocus(id) }
 func (a historyModelAdapter) Width() int                  { return a.model.Width() }
 func (a historyModelAdapter) Height() int                 { return a.model.Height() }

--- a/model_init.go
+++ b/model_init.go
@@ -195,7 +195,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 				m.connections.Active = cfg.Name
 				m.importer = importer.New(client, importFile)
 				m.components[modeImporter] = m.importer
-				m.setMode(modeImporter)
+				m.SetMode(modeImporter)
 			} else {
 				return nil, fmt.Errorf("connect error: %w", err)
 			}

--- a/run.go
+++ b/run.go
@@ -116,7 +116,7 @@ func Main() {
 	if err != nil {
 		log.Printf("Warning: %v", err)
 	}
-	_ = initial.setMode(modeConnections)
+	_ = initial.SetMode(modeConnections)
 	p := tea.NewProgram(initial, tea.WithMouseAllMotion(), tea.WithAltScreen())
 	finalModel, err := p.Run()
 	if err != nil {

--- a/update.go
+++ b/update.go
@@ -24,7 +24,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
-	if c, ok := m.components[m.currentMode()]; ok {
+	if c, ok := m.components[m.CurrentMode()]; ok {
 		cmd := c.Update(msg)
 		return m, cmd
 	}

--- a/update_client.go
+++ b/update_client.go
@@ -37,7 +37,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, cmd)
 	}
 
-	if m.currentMode() != modeConfirmDelete {
+	if m.CurrentMode() != modeConfirmDelete {
 		cmds = append(cmds, m.updateClientInputs(msg)...)
 		m.filterHistoryList()
 	}

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -21,7 +21,7 @@ func TestHandleMouseScrollTopics(t *testing.T) {
 	rowH := lipgloss.Height(ui.Chip.Render("t"))
 	m.layout.topics.height = rowH
 	m.viewClient()
-	m.setFocus(idTopics)
+	m.SetFocus(idTopics)
 	_, handled := m.handleMouseScroll(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
 	if !handled {
 		t.Fatalf("expected scroll event handled")
@@ -51,7 +51,7 @@ func TestHandleHistorySelectionShift(t *testing.T) {
 		items[i] = it
 	}
 	m.history.List().SetItems(items)
-	m.setFocus(idHistory)
+	m.SetFocus(idHistory)
 
 	m.history.HandleSelection(0, true)
 	if m.history.SelectionAnchor() != 0 {
@@ -98,7 +98,7 @@ func TestHandleHistoryClick(t *testing.T) {
 	items := []list.Item{m.history.Items()[0]}
 	m.history.List().SetItems(items)
 	m.viewClient()
-	m.setFocus(idHistory)
+	m.SetFocus(idHistory)
 	y := m.ui.elemPos[idHistory] + 1
 	m.history.HandleClick(tea.MouseMsg{Y: y}, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
 	if m.history.List().Index() != 0 {
@@ -117,7 +117,7 @@ func TestHistoryScroll(t *testing.T) {
 		items[i] = it
 	}
 	m.history.List().SetItems(items)
-	m.setFocus(idHistory)
+	m.SetFocus(idHistory)
 	_, handled := m.handleMouseScroll(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
 	if !handled {
 		t.Fatalf("expected scroll event handled")

--- a/update_connection_form.go
+++ b/update_connection_form.go
@@ -18,7 +18,7 @@ func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
 		case "ctrl+d":
 			return tea.Quit
 		case "esc":
-			cmd := m.setMode(modeConnections)
+			cmd := m.SetMode(modeConnections)
 			m.connections.Form = nil
 			return cmd
 		case "enter":
@@ -33,7 +33,7 @@ func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
 				m.connections.Manager.AddConnection(p)
 			}
 			m.connections.RefreshConnectionItems()
-			cmd := m.setMode(modeConnections)
+			cmd := m.SetMode(modeConnections)
 			m.connections.Form = nil
 			return cmd
 		}

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -42,14 +42,14 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 		m.ui.viewport.ScrollDown(1)
 		return nil, true
 	case "tab":
-		if m.currentMode() == modeHistoryFilter {
+		if m.CurrentMode() == modeHistoryFilter {
 			return m.history.UpdateFilter(msg), true
 		}
 		if len(m.ui.focusOrder) > 0 {
 			m.focus.Next()
 			m.ui.focusIndex = m.focus.Index()
 			id := m.ui.focusOrder[m.ui.focusIndex]
-			m.setFocus(id)
+			m.SetFocus(id)
 			if id == idTopics {
 				if len(m.topics.Items) > 0 {
 					sel := m.topics.Selected()
@@ -64,14 +64,14 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 			return nil, true
 		}
 	case "shift+tab":
-		if m.currentMode() == modeHistoryFilter {
+		if m.CurrentMode() == modeHistoryFilter {
 			return m.history.UpdateFilter(msg), true
 		}
 		if len(m.ui.focusOrder) > 0 {
 			m.focus.Prev()
 			m.ui.focusIndex = m.focus.Index()
 			id := m.ui.focusOrder[m.ui.focusIndex]
-			m.setFocus(id)
+			m.SetFocus(id)
 			if id == idTopics {
 				if len(m.topics.Items) > 0 {
 					sel := m.topics.Selected()
@@ -87,10 +87,10 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 	}
 
-	if m.currentMode() != modeHistoryFilter &&
+	if m.CurrentMode() != modeHistoryFilter &&
 		(msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
 		m.help.Focused() {
-		return m.setMode(modeHelp), true
+		return m.SetMode(modeHelp), true
 	}
 	return nil, false
 }

--- a/view.go
+++ b/view.go
@@ -31,7 +31,7 @@ func (m *model) OverlayHelp(view string) string { return m.overlayHelp(view) }
 
 // View renders the application UI based on the current mode.
 func (m *model) View() string {
-	if c, ok := m.components[m.currentMode()]; ok {
+	if c, ok := m.components[m.CurrentMode()]; ok {
 		return c.View()
 	}
 	return ""


### PR DESCRIPTION
## Summary
- rename internal helpers like `setFocus` and `scrollToFocused` to exported `SetFocus` and `ScrollToFocused`
- remove one-line wrappers and export underlying implementations
- update all call sites to use new exported helpers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891c12367648324b35c17c716aa94cc