### PR TITLE
Remove leftover history reference in model

### DIFF
--- a/model.go
+++ b/model.go
@@ -16,8 +16,6 @@ import (
 	"github.com/marang/emqutiti/traces"
 )
 
-// reference history package to avoid unused import warning
-var _ = history.ID
 var _ Handler = (*model)(nil)
 var _ message.Model = (*model)(nil)
 


### PR DESCRIPTION
## Summary
- drop leftover history comment and placeholder

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891c124233483248e273ea42c7b081c