### PR TITLE
handle subscribe errors

### DIFF
--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -31,7 +31,9 @@ func (m *model) SubscribeActiveTopics() {
 	}
 	for _, t := range m.topics.Items {
 		if t.Subscribed {
-			m.mqttClient.Subscribe(t.Name, 0, nil)
+			if err := m.mqttClient.Subscribe(t.Name, 0, nil); err != nil {
+				m.connections.SendStatus(fmt.Sprintf("Subscribe error for %s: %v", t.Name, err))
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- report subscription failures when restoring active topics

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891c32e678083248a7f16dd657fc738