### PR TITLE
Remove redundant copy log

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -53,9 +53,6 @@ func (m *model) handleCopyKey() tea.Cmd {
 			}
 			if err := clipboard.WriteAll(text); err != nil {
 				m.history.Append("", err.Error(), "log", err.Error())
-			} else {
-				msg := "Copied item"
-				m.history.Append("", msg, "log", msg)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- avoid logging when copying a single history item to the clipboard

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ccf284bc8324bf60595160ec7076