### PR TITLE
Handle subscribe errors in tracer runtime

### DIFF
--- a/traces/runtime.go
+++ b/traces/runtime.go
@@ -90,7 +90,7 @@ func (t *Tracer) Start() error {
 		}
 
 		for _, topic := range t.cfg.Topics {
-			client.Subscribe(topic, 0, func(_ mqtt.Client, m mqtt.Message) {
+			if err := client.Subscribe(topic, 0, func(_ mqtt.Client, m mqtt.Message) {
 				ts := time.Now()
 				if !t.cfg.End.IsZero() && ts.After(t.cfg.End) {
 					return
@@ -109,7 +109,10 @@ func (t *Tracer) Start() error {
 					}
 				}
 				t.mu.Unlock()
-			})
+			}); err != nil {
+				fmt.Printf("subscribe %s: %v\n", topic, err)
+				return
+			}
 		}
 
 		for {


### PR DESCRIPTION
## Summary
- handle subscription errors in tracer runtime and abort if any topic fails

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cd2e38bc8324b32471d84912da6a