### PR TITLE
traces: stop timer when end time is set

### DIFF
--- a/traces/runtime.go
+++ b/traces/runtime.go
@@ -82,11 +82,15 @@ func (t *Tracer) Start() error {
 		}
 
 		endCh := make(<-chan time.Time)
+		var timer *time.Timer
 		if !t.cfg.End.IsZero() {
 			if d := time.Until(t.cfg.End); d > 0 {
-				timer := time.NewTimer(d)
+				timer = time.NewTimer(d)
 				endCh = timer.C
 			}
+		}
+		if timer != nil {
+			defer timer.Stop()
 		}
 
 		for _, topic := range t.cfg.Topics {


### PR DESCRIPTION
## Summary
- stop trace timer when an end time is configured to avoid leaks

## Testing
- `gofmt -w traces/runtime.go`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cd437f408324b239bffeb3f57ee7