### PR TITLE
traces: send tracerAdd errors to report channel

### DIFF
--- a/traces/runtime.go
+++ b/traces/runtime.go
@@ -34,11 +34,21 @@ type Tracer struct {
 	client  Client
 	cancel  context.CancelFunc
 	done    chan struct{}
+	report  chan error
 }
 
 // newTracer creates a new Tracer with the given config.
 func newTracer(cfg TracerConfig, c Client) *Tracer {
-	return &Tracer{cfg: cfg, client: c}
+	return &Tracer{cfg: cfg, client: c, report: make(chan error, 1)}
+}
+
+func (t *Tracer) reportErr(err error) {
+	if t.report != nil {
+		select {
+		case t.report <- err:
+		default:
+		}
+	}
 }
 
 // Start begins the trace.
@@ -70,6 +80,9 @@ func (t *Tracer) Start() error {
 			t.cancel = nil
 			t.mu.Unlock()
 			close(t.done)
+			if t.report != nil {
+				close(t.report)
+			}
 		}()
 
 		delay := time.Until(t.cfg.Start)
@@ -99,7 +112,7 @@ func (t *Tracer) Start() error {
 					return
 				}
 				if err := tracerAdd(t.cfg.Profile, t.cfg.Key, TracerMessage{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"}); err != nil {
-					fmt.Printf("tracerAdd: %v\n", err)
+					t.reportErr(fmt.Errorf("tracerAdd: %w", err))
 					return
 				}
 				t.mu.Lock()


### PR DESCRIPTION
## Summary
- route `tracerAdd` failures through the tracer's error channel
- close reporting channel on shutdown

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cd595d388324b8b78b8830f6e9b9