### PR TITLE
traces: remove duplicate Run comment

### DIFF
--- a/traces/headless.go
+++ b/traces/headless.go
@@ -85,7 +85,6 @@ func (m *mqttClient) Disconnect() {
 }
 
 // Run executes the tracer headlessly using configuration from config.toml.
-// Run executes the tracer headlessly using configuration from config.toml.
 func Run(key, topics, profileName, startStr, endStr string) error {
 	if key == "" || topics == "" {
 		return fmt.Errorf("-trace and -topics are required")


### PR DESCRIPTION
## Summary
- remove redundant "Run" comment in headless tracer

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cd64b26883248f8955f98958f81c