### PR TITLE
mqttclient: remove direct logging in callbacks

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	connections "github.com/marang/emqutiti/connections"
-	"log"
 	"strconv"
 	"time"
 
@@ -66,13 +65,11 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 		opts.SetTLSConfig(&tls.Config{InsecureSkipVerify: p.SkipTLSVerify})
 	}
 	opts.OnConnect = func(client mqtt.Client) {
-		log.Println("Connected to MQTT broker")
 		if fn != nil {
 			fn("Connected to MQTT broker")
 		}
 	}
 	opts.OnConnectionLost = func(client mqtt.Client, err error) {
-		log.Printf("Connection lost: %v", err)
 		if fn != nil {
 			fn(fmt.Sprintf("Connection lost: %v", err))
 		}


### PR DESCRIPTION
## Summary
- rely on status callback for connect/loss events

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891cd861a88832491a6f866d7a7e40c