### PR TITLE
Use map for constant-time focus lookups

### DIFF
--- a/focus.go
+++ b/focus.go
@@ -4,12 +4,9 @@ import tea "github.com/charmbracelet/bubbletea"
 
 // SetFocus moves focus to the given element id.
 func (m *model) SetFocus(id string) tea.Cmd {
-	for i, name := range m.ui.focusOrder {
-		if name == id {
-			m.focus.Set(i)
-			m.ui.focusIndex = m.focus.Index()
-			break
-		}
+	if i, ok := m.ui.focusMap[id]; ok {
+		m.focus.Set(i)
+		m.ui.focusIndex = m.focus.Index()
 	}
 	m.ScrollToFocused()
 	return nil

--- a/model.go
+++ b/model.go
@@ -94,6 +94,7 @@ type uiState struct {
 	viewport   viewport.Model // scrolling container for the main view
 	elemPos    map[string]int // cached Y positions of each box
 	focusOrder []string       // order of focusable elements
+	focusMap   map[string]int // maps element IDs to their index
 }
 
 type model struct {

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -97,8 +97,10 @@ func (m *model) SetMode(mode appMode) tea.Cmd {
 		order = []string{idHelp}
 	}
 	m.ui.focusOrder = append([]string(nil), order...)
+	m.ui.focusMap = make(map[string]int, len(order))
 	items := make([]focus.Focusable, len(order))
 	for i, id := range order {
+		m.ui.focusMap[id] = i
 		if f := m.focusables[id]; f != nil {
 			items[i] = f
 		} else {

--- a/model_init.go
+++ b/model_init.go
@@ -87,6 +87,10 @@ func initMessage() message.State {
 
 func initUI(order []string) uiState {
 	vp := viewport.New(0, 0)
+	fm := make(map[string]int, len(order))
+	for i, id := range order {
+		fm[id] = i
+	}
 	return uiState{
 		focusIndex: 0,
 		modeStack:  []appMode{modeClient},
@@ -95,6 +99,7 @@ func initUI(order []string) uiState {
 		viewport:   vp,
 		elemPos:    map[string]int{},
 		focusOrder: order,
+		focusMap:   fm,
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a map from element IDs to their focus indices
- rebuild the map whenever focus order changes
- switch SetFocus to use the map for instant lookups

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d80031408324a1fec2920b83a947