### PR TITLE
refactor: use constant for history delegate height

### DIFF
--- a/model_helpers.go
+++ b/model_helpers.go
@@ -9,14 +9,17 @@ import (
 	"github.com/marang/emqutiti/history"
 )
 
+// historyDelegateHeight matches historyDelegate.Height(); history items render a
+// header and payload line, so each entry is two rows tall.
+const historyDelegateHeight = 2
+
 // historyIndexAt converts a Y coordinate into an index within the history list.
 func (m *model) historyIndexAt(y int) int {
 	rel := y - (m.ui.elemPos[idHistory] + 1) + m.ui.viewport.YOffset
 	if rel < 0 {
 		return -1
 	}
-	h := 2 // historyDelegate height
-	idx := rel / h
+	idx := rel / historyDelegateHeight
 	lst := m.history.List()
 	start := lst.Paginator.Page * lst.Paginator.PerPage
 	i := start + idx


### PR DESCRIPTION
## Summary
- introduce `historyDelegateHeight` constant
- replace literal value in `historyIndexAt`
- document why history delegate height is two rows

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d7ea08fc83248533ef7d6d9e8d45