### PR TITLE
Centralize mode and element ID constants

### DIFF
--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -104,5 +105,5 @@ func (m *model) handleHistoryViewKey() tea.Cmd {
 	m.history.SetDetailItem(hi)
 	m.history.Detail().SetContent(hi.Payload)
 	m.history.Detail().SetYOffset(0)
-	return m.SetMode(modeHistoryDetail)
+	return m.SetMode(constants.ModeHistoryDetail)
 }

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -2,6 +2,8 @@ package emqutiti
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
 )
 
 // handleTabKey moves focus forward.
@@ -94,19 +96,19 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 		m.connections.RefreshConnectionItems()
 		m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
 		m.traces.SavePlannedTraces()
-		return m.SetMode(modeConnections)
+		return m.SetMode(constants.ModeConnections)
 	case "ctrl+t":
 		m.topics.SetActivePane(0)
 		m.topics.RebuildActiveTopicList()
 		m.topics.SetSelected(0)
 		m.topics.List().SetSize(m.ui.width/2-4, m.ui.height-4)
-		return m.SetMode(modeTopics)
+		return m.SetMode(constants.ModeTopics)
 	case "ctrl+p":
 		m.payloads.List().SetSize(m.ui.width-4, m.ui.height-4)
-		return m.SetMode(modePayloads)
+		return m.SetMode(constants.ModePayloads)
 	case "ctrl+r":
 		m.traces.List().SetSize(m.ui.width-4, m.ui.height-4)
-		return m.SetMode(modeTracer)
+		return m.SetMode(constants.ModeTracer)
 	default:
 		return nil
 	}

--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/topics"
 )
 
@@ -47,7 +48,7 @@ func (m *model) handleEnterKey() tea.Cmd {
 		if topic != "" && !m.topics.HasTopic(topic) {
 			m.topics.Items = append(m.topics.Items, topics.Item{Name: topic, Subscribed: true})
 			m.topics.SortTopics()
-			if m.CurrentMode() == modeTopics {
+			if m.CurrentMode() == constants.ModeTopics {
 				m.topics.RebuildActiveTopicList()
 			}
 			m.topics.Input.SetValue("")
@@ -73,7 +74,7 @@ func (m *model) handleDeleteTopicKey() tea.Cmd {
 	rf := func() tea.Cmd { return m.SetFocus(m.ui.focusOrder[m.ui.focusIndex]) }
 	m.StartConfirm(fmt.Sprintf("Delete topic '%s'? [y/n]", name), "", rf, func() tea.Cmd {
 		cmd := m.topics.RemoveTopic(idx)
-		if m.CurrentMode() == modeTopics {
+		if m.CurrentMode() == constants.ModeTopics {
 			m.topics.RebuildActiveTopicList()
 		}
 		return cmd

--- a/connections/api.go
+++ b/connections/api.go
@@ -3,6 +3,8 @@ package connections
 import (
 	tea "github.com/charmbracelet/bubbletea"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+
+	"github.com/marang/emqutiti/constants"
 )
 
 // Client defines the MQTT functions used by the connections package.
@@ -47,7 +49,7 @@ type API interface {
 
 // Navigator exposes navigation helpers required by the component.
 type Navigator interface {
-	SetMode(mode int) tea.Cmd
+	SetMode(mode constants.AppMode) tea.Cmd
 	Width() int
 	Height() int
 }

--- a/connections/component.go
+++ b/connections/component.go
@@ -8,15 +8,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/ui"
-)
-
-const (
-	modeClient         = 0
-	modeConnections    = 1
-	modeEditConnection = 2
-	modeTracer         = 6
-	idConnList         = "conn-list"
 )
 
 // connectionItem represents a single broker profile in the list.
@@ -123,7 +116,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 	case ConnectResult:
 		c.api.HandleConnectResult(msg)
 		if msg.Err == nil {
-			cmd = c.nav.SetMode(modeClient)
+			cmd = c.nav.SetMode(constants.ModeClient)
 			return tea.Batch(cmd, c.api.ListenStatus())
 		}
 		return c.api.ListenStatus()
@@ -140,7 +133,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 						c.api.SetConnectionMessage("Connected to " + brokerURL)
 						c.api.SetConnected(p.Name)
 						c.api.RefreshConnectionItems()
-						return c.nav.SetMode(modeClient)
+						return c.nav.SetMode(constants.ModeClient)
 					}
 					return c.api.Connect(p)
 				}
@@ -152,7 +145,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 			return tea.Quit
 		case "ctrl+r":
 			c.api.ResizeTraces(c.nav.Width()-4, c.nav.Height()-4)
-			return c.nav.SetMode(modeTracer)
+			return c.nav.SetMode(constants.ModeTracer)
 		case "ctrl+o":
 			i := mgr.ConnectionsList.Index()
 			if i >= 0 {
@@ -164,12 +157,12 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 			}
 		case "a":
 			c.api.BeginAdd()
-			return c.nav.SetMode(modeEditConnection)
+			return c.nav.SetMode(constants.ModeEditConnection)
 		case "e":
 			i := mgr.ConnectionsList.Index()
 			if i >= 0 && i < len(mgr.Profiles) {
 				c.api.BeginEdit(i)
-				return c.nav.SetMode(modeEditConnection)
+				return c.nav.SetMode(constants.ModeEditConnection)
 			}
 		case "enter":
 			i := mgr.ConnectionsList.Index()
@@ -180,7 +173,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 					c.api.SetConnectionMessage("Connected to " + brokerURL)
 					c.api.SetConnected(p.Name)
 					c.api.RefreshConnectionItems()
-					return c.nav.SetMode(modeClient)
+					return c.nav.SetMode(constants.ModeClient)
 				}
 				return c.api.Connect(p)
 			}
@@ -202,7 +195,7 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 // View renders the connections UI component.
 func (c *Component) View() string {
 	c.api.ResetElemPos()
-	c.api.SetElemPos(idConnList, 1)
+	c.api.SetElemPos(constants.IDConnList, 1)
 	listView := c.api.Manager().ConnectionsList.View()
 	help := ui.InfoStyle.Render("[enter] connect/open client  [x] disconnect  [a]dd [e]dit [del] delete  Ctrl+O default  Ctrl+R traces")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)
@@ -221,7 +214,7 @@ func (c *Component) Blur() { c.api.Manager().Focused = false }
 
 // Focusables exposes focusable elements for the connections component.
 func (c *Component) Focusables() map[string]Focusable {
-	return map[string]Focusable{idConnList: &nullFocusable{}}
+	return map[string]Focusable{constants.IDConnList: &nullFocusable{}}
 }
 
 // nullFocusable is a no-op focusable used for non-interactive areas.

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -1,0 +1,25 @@
+package constants
+
+// AppMode defines application modes.
+type AppMode int
+
+const (
+	ModeClient AppMode = iota
+	ModeConnections
+	ModeEditConnection
+	ModeConfirmDelete
+	ModeTopics
+	ModePayloads
+	ModeTracer
+	ModeEditTrace
+	ModeViewTrace
+	ModeImporter
+	ModeHistoryFilter
+	ModeHistoryDetail
+	ModeHelp
+)
+
+// ID constants for shared elements.
+const (
+	IDConnList = "conn-list"
+)

--- a/help/api.go
+++ b/help/api.go
@@ -2,6 +2,7 @@ package help
 
 import (
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/focus"
 )
 
@@ -10,8 +11,8 @@ const ID = "help"
 
 // Navigator provides navigation control for the help component.
 type Navigator interface {
-	SetMode(mode int) tea.Cmd
-	PreviousMode() int
+	SetMode(mode constants.AppMode) tea.Cmd
+	PreviousMode() constants.AppMode
 	Width() int
 	Height() int
 }

--- a/help/help_test.go
+++ b/help/help_test.go
@@ -6,14 +6,16 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
 )
 
-type testNav struct{ mode int }
+type testNav struct{ mode constants.AppMode }
 
-func (t *testNav) SetMode(mode int) tea.Cmd { t.mode = mode; return nil }
-func (t *testNav) PreviousMode() int        { return 7 }
-func (t *testNav) Width() int               { return 0 }
-func (t *testNav) Height() int              { return 0 }
+func (t *testNav) SetMode(mode constants.AppMode) tea.Cmd { t.mode = mode; return nil }
+func (t *testNav) PreviousMode() constants.AppMode        { return constants.ModeHelp }
+func (t *testNav) Width() int                             { return 0 }
+func (t *testNav) Height() int                            { return 0 }
 
 func TestEscReturnsToPreviousMode(t *testing.T) {
 	w, h := 0, 0

--- a/model.go
+++ b/model.go
@@ -14,6 +14,8 @@ import (
 	"github.com/marang/emqutiti/payloads"
 	"github.com/marang/emqutiti/topics"
 	"github.com/marang/emqutiti/traces"
+
+	"github.com/marang/emqutiti/constants"
 )
 
 var _ Handler = (*model)(nil)
@@ -87,13 +89,13 @@ type layoutConfig struct {
 
 // uiState groups general UI information such as current focus and layout.
 type uiState struct {
-	focusIndex int            // index of the currently focused element
-	modeStack  []appMode      // mode stack, index 0 is current
-	width      int            // terminal width
-	height     int            // terminal height
-	viewport   viewport.Model // scrolling container for the main view
-	elemPos    map[string]int // cached Y positions of each box
-	focusOrder []string       // order of focusable elements
+	focusIndex int                 // index of the currently focused element
+	modeStack  []constants.AppMode // mode stack, index 0 is current
+	width      int                 // terminal width
+	height     int                 // terminal height
+	viewport   viewport.Model      // scrolling container for the main view
+	elemPos    map[string]int      // cached Y positions of each box
+	focusOrder []string            // order of focusable elements
 }
 
 type model struct {
@@ -117,7 +119,7 @@ type model struct {
 	// components maps each application mode to its corresponding component
 	// implementation. These components handle mode-specific update and view
 	// logic which the model delegates to at runtime.
-	components map[appMode]Component
+	components map[constants.AppMode]Component
 
 	focusables map[string]focus.Focusable
 	focus      *focus.FocusMap

--- a/model_base.go
+++ b/model_base.go
@@ -1,6 +1,7 @@
 package emqutiti
 
 import (
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/message"
 	"github.com/marang/emqutiti/payloads"
@@ -12,43 +13,24 @@ const (
 	idTopic              = "topic"               // topic input box
 	idMessage            = message.ID            // message input box
 	idHistory            = "history"             // history list
-	idConnList           = "conn-list"           // broker list
 	idTopicsSubscribed   = "topics-subscribed"   // subscribed topics pane
 	idTopicsUnsubscribed = "topics-unsubscribed" // unsubscribed topics pane
 	idPayloadList        = payloads.IDList       // payload manager list
 	idHelp               = help.ID               // help icon
 )
 
-type appMode int
-
-const (
-	modeClient appMode = iota
-	modeConnections
-	modeEditConnection
-	modeConfirmDelete
-	modeTopics
-	modePayloads
-	modeTracer
-	modeEditTrace
-	modeViewTrace
-	modeImporter
-	modeHistoryFilter
-	modeHistoryDetail
-	modeHelp
-)
-
-var focusByMode = map[appMode][]string{
-	modeClient:         {idTopics, idTopic, idMessage, idHistory, idHelp},
-	modeConnections:    {idConnList, idHelp},
-	modeEditConnection: {idConnList, idHelp},
-	modeConfirmDelete:  {},
-	modeTopics:         {idTopicsSubscribed, idTopicsUnsubscribed, idHelp},
-	modePayloads:       {idPayloadList, idHelp},
-	modeTracer:         {traces.IDList, idHelp},
-	modeEditTrace:      {idHelp},
-	modeViewTrace:      {idHelp},
-	modeImporter:       {idHelp},
-	modeHistoryFilter:  {idHelp},
-	modeHistoryDetail:  {idHelp},
-	modeHelp:           {idHelp},
+var focusByMode = map[constants.AppMode][]string{
+	constants.ModeClient:         {idTopics, idTopic, idMessage, idHistory, idHelp},
+	constants.ModeConnections:    {constants.IDConnList, idHelp},
+	constants.ModeEditConnection: {constants.IDConnList, idHelp},
+	constants.ModeConfirmDelete:  {},
+	constants.ModeTopics:         {idTopicsSubscribed, idTopicsUnsubscribed, idHelp},
+	constants.ModePayloads:       {idPayloadList, idHelp},
+	constants.ModeTracer:         {traces.IDList, idHelp},
+	constants.ModeEditTrace:      {idHelp},
+	constants.ModeViewTrace:      {idHelp},
+	constants.ModeImporter:       {idHelp},
+	constants.ModeHistoryFilter:  {idHelp},
+	constants.ModeHistoryDetail:  {idHelp},
+	constants.ModeHelp:           {idHelp},
 }

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/marang/emqutiti/confirm"
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/history"
 )
@@ -42,7 +43,7 @@ func (m *model) SetElemPos(id string, pos int) { m.ui.elemPos[id] = pos }
 func (m *model) StartConfirm(prompt, info string, returnFocus func() tea.Cmd, action func() tea.Cmd, cancel func()) {
 	m.confirm = confirm.NewComponent(m, m, returnFocus, action, cancel)
 	m.confirm.Start(prompt, info)
-	m.components[modeConfirmDelete] = m.confirm
+	m.components[constants.ModeConfirmDelete] = m.confirm
 }
 
 // startHistoryFilter opens the history filter form.
@@ -65,11 +66,11 @@ func (m *model) startHistoryFilter() tea.Cmd {
 	}
 	hf := history.NewFilterForm(topics, topic, payload, start, end, m.history.ShowArchived())
 	m.history.SetFilterForm(&hf)
-	return m.SetMode(modeHistoryFilter)
+	return m.SetMode(constants.ModeHistoryFilter)
 }
 
 // SetMode updates the current mode and focus order.
-func (m *model) SetMode(mode appMode) tea.Cmd {
+func (m *model) SetMode(mode constants.AppMode) tea.Cmd {
 	if m.focus != nil && len(m.ui.focusOrder) > m.ui.focusIndex {
 		if f, ok := m.focusables[m.ui.focusOrder[m.ui.focusIndex]]; ok {
 			f.Blur()
@@ -77,7 +78,7 @@ func (m *model) SetMode(mode appMode) tea.Cmd {
 	}
 	// push mode to stack
 	if len(m.ui.modeStack) == 0 || m.ui.modeStack[0] != mode {
-		m.ui.modeStack = append([]appMode{mode}, m.ui.modeStack...)
+		m.ui.modeStack = append([]constants.AppMode{mode}, m.ui.modeStack...)
 	} else {
 		m.ui.modeStack[0] = mode
 	}
@@ -112,15 +113,15 @@ func (m *model) SetMode(mode appMode) tea.Cmd {
 }
 
 // CurrentMode returns the active application mode.
-func (m *model) CurrentMode() appMode {
+func (m *model) CurrentMode() constants.AppMode {
 	if len(m.ui.modeStack) == 0 {
-		return modeClient
+		return constants.ModeClient
 	}
 	return m.ui.modeStack[0]
 }
 
 // PreviousMode returns the last mode before the current one.
-func (m *model) PreviousMode() appMode {
+func (m *model) PreviousMode() constants.AppMode {
 	if len(m.ui.modeStack) > 1 {
 		return m.ui.modeStack[1]
 	}
@@ -128,7 +129,7 @@ func (m *model) PreviousMode() appMode {
 }
 
 // SetConfirmMode switches to the confirmation screen.
-func (m *model) SetConfirmMode() tea.Cmd { return m.SetMode(modeConfirmDelete) }
+func (m *model) SetConfirmMode() tea.Cmd { return m.SetMode(constants.ModeConfirmDelete) }
 
 // SetPreviousMode returns to the prior screen.
 func (m *model) SetPreviousMode() tea.Cmd { return m.SetMode(m.PreviousMode()) }
@@ -143,4 +144,4 @@ func (m *model) MessageHeight() int { return m.layout.message.height }
 func (m *model) Height() int { return m.ui.height }
 
 // SetClientMode switches to the main client screen.
-func (m *model) SetClientMode() tea.Cmd { return m.SetMode(modeClient) }
+func (m *model) SetClientMode() tea.Cmd { return m.SetMode(constants.ModeClient) }

--- a/model_history.go
+++ b/model_history.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/ui"
 )
@@ -19,7 +20,7 @@ const historyPreviewLimit = 256
 type historyModelAdapter struct{ *model }
 
 func (a historyModelAdapter) SetMode(mode history.Mode) tea.Cmd {
-	if am, ok := mode.(appMode); ok {
+	if am, ok := mode.(constants.AppMode); ok {
 		return a.model.SetMode(am)
 	}
 	return nil

--- a/model_init.go
+++ b/model_init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/marang/emqutiti/confirm"
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/importer"
@@ -25,10 +26,10 @@ import (
 
 type navAdapter struct{ navigator }
 
-func (n navAdapter) SetMode(mode int) tea.Cmd { return n.navigator.SetMode(appMode(mode)) }
-func (n navAdapter) Width() int               { return n.navigator.Width() }
-func (n navAdapter) Height() int              { return n.navigator.Height() }
-func (n navAdapter) PreviousMode() int        { return int(n.navigator.PreviousMode()) }
+func (n navAdapter) SetMode(mode constants.AppMode) tea.Cmd { return n.navigator.SetMode(mode) }
+func (n navAdapter) Width() int                             { return n.navigator.Width() }
+func (n navAdapter) Height() int                            { return n.navigator.Height() }
+func (n navAdapter) PreviousMode() constants.AppMode        { return n.navigator.PreviousMode() }
 
 func initConnections(conns *connections.Connections) (connections.State, error) {
 	var connModel connections.Connections
@@ -89,7 +90,7 @@ func initUI(order []string) uiState {
 	vp := viewport.New(0, 0)
 	return uiState{
 		focusIndex: 0,
-		modeStack:  []appMode{modeClient},
+		modeStack:  []constants.AppMode{constants.ModeClient},
 		width:      0,
 		height:     0,
 		viewport:   vp,
@@ -109,7 +110,7 @@ func initLayout() layoutConfig {
 
 // initialModel creates the main program model with optional connection data.
 func initialModel(conns *connections.Connections) (*model, error) {
-	order := append([]string(nil), focusByMode[modeClient]...)
+	order := append([]string(nil), focusByMode[constants.ModeClient]...)
 	cs, loadErr := initConnections(conns)
 	st, _ := history.OpenStore("")
 	ms := initMessage()
@@ -148,19 +149,19 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.traces.ViewList().SetDelegate(traceDel)
 	// Register mode components so that view and update logic can be
 	// delegated based on the current application mode.
-	m.components = map[appMode]Component{
-		modeClient:         component{update: m.updateClient, view: m.viewClient},
-		modeConnections:    connComp,
-		modeEditConnection: component{update: m.updateConnectionForm, view: m.viewForm},
-		modeConfirmDelete:  m.confirm,
-		modeTopics:         topicsComp,
-		modePayloads:       m.payloads,
-		modeTracer:         tracesComp,
-		modeEditTrace:      component{update: m.traces.UpdateForm, view: m.traces.ViewForm},
-		modeViewTrace:      component{update: m.traces.UpdateView, view: m.traces.ViewMessages},
-		modeHistoryFilter:  component{update: m.history.UpdateFilter, view: m.history.ViewFilter},
-		modeHistoryDetail:  component{update: m.history.UpdateDetail, view: m.history.ViewDetail},
-		modeHelp:           m.help,
+	m.components = map[constants.AppMode]Component{
+		constants.ModeClient:         component{update: m.updateClient, view: m.viewClient},
+		constants.ModeConnections:    connComp,
+		constants.ModeEditConnection: component{update: m.updateConnectionForm, view: m.viewForm},
+		constants.ModeConfirmDelete:  m.confirm,
+		constants.ModeTopics:         topicsComp,
+		constants.ModePayloads:       m.payloads,
+		constants.ModeTracer:         tracesComp,
+		constants.ModeEditTrace:      component{update: m.traces.UpdateForm, view: m.traces.ViewForm},
+		constants.ModeViewTrace:      component{update: m.traces.UpdateView, view: m.traces.ViewMessages},
+		constants.ModeHistoryFilter:  component{update: m.history.UpdateFilter, view: m.history.ViewFilter},
+		constants.ModeHistoryDetail:  component{update: m.history.UpdateDetail, view: m.history.ViewDetail},
+		constants.ModeHelp:           m.help,
 	}
 
 	if importFile != "" {
@@ -194,8 +195,8 @@ func initialModel(conns *connections.Connections) (*model, error) {
 				m.mqttClient = client
 				m.connections.Active = cfg.Name
 				m.importer = importer.New(client, importFile)
-				m.components[modeImporter] = m.importer
-				m.SetMode(modeImporter)
+				m.components[constants.ModeImporter] = m.importer
+				m.SetMode(constants.ModeImporter)
 			} else {
 				return nil, fmt.Errorf("connect error: %w", err)
 			}

--- a/model_topics_api.go
+++ b/model_topics_api.go
@@ -1,8 +1,12 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
 
 // ShowClient switches the UI back to the main client view.
 func (m *model) ShowClient() tea.Cmd {
-	return m.SetMode(modeClient)
+	return m.SetMode(constants.ModeClient)
 }

--- a/navigator.go
+++ b/navigator.go
@@ -1,10 +1,14 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
 
 type navigator interface {
-	SetMode(appMode) tea.Cmd
-	PreviousMode() appMode
+	SetMode(constants.AppMode) tea.Cmd
+	PreviousMode() constants.AppMode
 	Width() int
 	Height() int
 }

--- a/run.go
+++ b/run.go
@@ -11,6 +11,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/importer"
 	"github.com/marang/emqutiti/traces"
 )
@@ -116,7 +117,7 @@ func Main() {
 	if err != nil {
 		log.Printf("Warning: %v", err)
 	}
-	_ = initial.SetMode(modeConnections)
+	_ = initial.SetMode(constants.ModeConnections)
 	p := tea.NewProgram(initial, tea.WithMouseAllMotion(), tea.WithAltScreen())
 	finalModel, err := p.Run()
 	if err != nil {

--- a/traces_api_impl.go
+++ b/traces_api_impl.go
@@ -4,14 +4,16 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/marang/emqutiti/connections"
 	"github.com/marang/emqutiti/traces"
+
+	"github.com/marang/emqutiti/constants"
 )
 
 func (m *model) tracesStore() traces.Store { return traces.FileStore{} }
 
-func (m *model) SetModeClient() tea.Cmd    { return m.SetMode(modeClient) }
-func (m *model) SetModeTracer() tea.Cmd    { return m.SetMode(modeTracer) }
-func (m *model) SetModeEditTrace() tea.Cmd { return m.SetMode(modeEditTrace) }
-func (m *model) SetModeViewTrace() tea.Cmd { return m.SetMode(modeViewTrace) }
+func (m *model) SetModeClient() tea.Cmd    { return m.SetMode(constants.ModeClient) }
+func (m *model) SetModeTracer() tea.Cmd    { return m.SetMode(constants.ModeTracer) }
+func (m *model) SetModeEditTrace() tea.Cmd { return m.SetMode(constants.ModeEditTrace) }
+func (m *model) SetModeViewTrace() tea.Cmd { return m.SetMode(constants.ModeViewTrace) }
 
 func (m *model) Profiles() []connections.Profile { return m.connections.Manager.Profiles }
 

--- a/update_client.go
+++ b/update_client.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	connections "github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/topics"
 )
 
@@ -48,7 +49,7 @@ func (m *model) updateClient(msg tea.Msg) tea.Cmd {
 		cmds = append(cmds, cmd)
 	}
 
-	if m.CurrentMode() != modeConfirmDelete {
+	if m.CurrentMode() != constants.ModeConfirmDelete {
 		cmds = append(cmds, m.updateClientInputs(msg)...)
 		m.filterHistoryList()
 	}

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -10,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/topics"
 )
@@ -101,8 +102,8 @@ func TestHandleClientKeyFilterInitiation(t *testing.T) {
 
 	HandleClientKey(m, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'/'}})
 
-	if m.ui.modeStack[0] != modeHistoryFilter {
-		t.Fatalf("expected modeHistoryFilter, got %v", m.ui.modeStack[0])
+	if m.ui.modeStack[0] != constants.ModeHistoryFilter {
+		t.Fatalf("expected ModeHistoryFilter, got %v", m.ui.modeStack[0])
 	}
 	if m.history.FilterForm() == nil {
 		t.Fatalf("expected filter form to be initialized")

--- a/update_connection_form.go
+++ b/update_connection_form.go
@@ -1,6 +1,10 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
 
 // updateConnectionForm handles the add/edit connection form.
 func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
@@ -18,7 +22,7 @@ func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
 		case "ctrl+d":
 			return tea.Quit
 		case "esc":
-			cmd := m.SetMode(modeConnections)
+			cmd := m.SetMode(constants.ModeConnections)
 			m.connections.Form = nil
 			return cmd
 		case "enter":
@@ -33,7 +37,7 @@ func (m *model) updateConnectionForm(msg tea.Msg) tea.Cmd {
 				m.connections.Manager.AddConnection(p)
 			}
 			m.connections.RefreshConnectionItems()
-			cmd := m.SetMode(modeConnections)
+			cmd := m.SetMode(constants.ModeConnections)
 			m.connections.Form = nil
 			return cmd
 		}

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -1,6 +1,10 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
 
 // handleWindowSize adjusts the layout when the terminal is resized.
 func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
@@ -42,7 +46,7 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 		m.ui.viewport.ScrollDown(1)
 		return nil, true
 	case "tab":
-		if m.CurrentMode() == modeHistoryFilter {
+		if m.CurrentMode() == constants.ModeHistoryFilter {
 			return m.history.UpdateFilter(msg), true
 		}
 		if len(m.ui.focusOrder) > 0 {
@@ -64,7 +68,7 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 			return nil, true
 		}
 	case "shift+tab":
-		if m.CurrentMode() == modeHistoryFilter {
+		if m.CurrentMode() == constants.ModeHistoryFilter {
 			return m.history.UpdateFilter(msg), true
 		}
 		if len(m.ui.focusOrder) > 0 {
@@ -87,10 +91,10 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 		}
 	}
 
-	if m.CurrentMode() != modeHistoryFilter &&
+	if m.CurrentMode() != constants.ModeHistoryFilter &&
 		(msg.String() == "enter" || msg.String() == " " || msg.String() == "space") &&
 		m.help.Focused() {
-		return m.SetMode(modeHelp), true
+		return m.SetMode(constants.ModeHelp), true
 	}
 	return nil, false
 }

--- a/view_form.go
+++ b/view_form.go
@@ -3,13 +3,14 @@ package emqutiti
 import (
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/ui"
 )
 
 // viewForm renders the add/edit broker form alongside the list.
 func (m *model) viewForm() string {
 	m.ui.elemPos = map[string]int{}
-	m.ui.elemPos[idConnList] = 1
+	m.ui.elemPos[constants.IDConnList] = 1
 	if m.connections.Form == nil {
 		return ""
 	}


### PR DESCRIPTION
## Summary
- add constants package exposing AppMode and shared element IDs
- refactor connections component and navigator APIs to use shared constants

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891d81032f883249ddc91c8b0d6a4fd