### PR TITLE
Guard history copy shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ Tips:
 
 | Action | Key |
 | --- | --- |
-| Copy selected entry | `Ctrl+C` |
 | Exit the program | `Ctrl+D` |
 | Manage payloads | `Ctrl+P` |
 | Manage topics | `Ctrl+T` |
@@ -101,6 +100,7 @@ Tips:
 #### History View
 
 - Shift selects ranges; `Ctrl+A` selects all
+- `Ctrl+C` copies selected history entries
 - `a` archives selected messages
 - `Delete` removes selected messages
 - `Ctrl+L` toggles archived view

--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -42,6 +42,9 @@ func (m *model) copyHistoryItems(items []history.Item) (int, error) {
 
 // handleCopyKey copies selected or current history items to the clipboard.
 func (m *model) handleCopyKey() tea.Cmd {
+	if m.ui.focusOrder[m.ui.focusIndex] != idHistory {
+		return nil
+	}
 	var selected []history.Item
 	hitems := m.history.Items()
 	for _, it := range hitems {

--- a/help/help.md
+++ b/help/help.md
@@ -4,7 +4,6 @@
 
 | Key | Action |
 | --- | ------ |
-| Ctrl+C | Copy selected entry |
 | Ctrl+D | Exit the program |
 | Ctrl+P | Manage payloads |
 | Ctrl+T | Manage topics |
@@ -53,6 +52,7 @@
 | Space | Toggle selection |
 | Shift+Up / Shift+Down | Extend selection |
 | Ctrl+A | Select all |
+| Ctrl+C | Copy selected history entries |
 | a | Archive selected messages |
 | Delete | Remove selected messages |
 | Ctrl+L | Toggle archived view |

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -52,6 +52,7 @@ func TestHandleClientKeyCopySelected(t *testing.T) {
 	m.history.SetItems([]history.Item{hi})
 	m.history.List().SetItems([]list.Item{hi})
 	m.history.List().Select(0)
+	m.SetFocus(idHistory)
 
 	HandleClientKey(m, tea.KeyMsg{Type: tea.KeyCtrlC})
 


### PR DESCRIPTION
## Summary
- Document Ctrl+C as a history view shortcut and drop it from global docs.
- Copy shortcut now runs only when the history pane has focus.
- Adjust tests for the new focus requirement.

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891e8b891c083249a814717fae2eeb0