### PR TITLE
traces: handle missing trace db

### DIFF
--- a/traces/store_test.go
+++ b/traces/store_test.go
@@ -37,6 +37,19 @@ func TestHasDataAndClear(t *testing.T) {
 	}
 }
 
+func TestHasDataEmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	has, err := tracerHasData("test", "k1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if has {
+		t.Fatalf("expected no data")
+	}
+}
+
 func TestTracerAddError(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)


### PR DESCRIPTION
## Summary
- ensure trace store checks for a Badger manifest before opening in read-only mode
- treat missing manifest as no data in `HasData`
- add regression test for empty trace database

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891f07d3680832482d751eb8bb4e6e6