### PR TITLE
docs: consolidate navigation keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,19 @@ Tips:
 | Manage topics | `Ctrl+T` |
 | Manage traces | `Ctrl+R` |
 | Open broker manager | `Ctrl+B` |
+| Disconnect from broker | `Ctrl+X` |
 | Publish message | `Ctrl+S` or `Ctrl+Enter` |
-| Clear history filters | `Ctrl+F` |
 | Resize panels | `Ctrl+Shift+Up` / `Ctrl+Shift+Down` |
-| Scroll view | `Ctrl+Up`/`Ctrl+Down` or `Ctrl+K`/`Ctrl+J` |
+| Scroll view | `Up`/`Down` or `j`/`k` |
 
 #### Navigation
 
-- `Esc` navigates back
-- Enter subscribes to the typed topic
-- Tab/Shift+Tab cycle focus
-- Use ↑/↓ or `j`/`k` to move through lists
-- All `Ctrl` shortcuts work even when an input is active
+| Action | Key |
+| --- | --- |
+| Back | `Esc` |
+| Cycle focus | `Tab` / `Shift+Tab` |
+| Scroll view | `Up`/`Down` or `j`/`k` |
+| Switch pane | `Left` / `Right` |
 
 #### Broker Manager
 

--- a/help/help.md
+++ b/help/help.md
@@ -12,10 +12,15 @@
 | Ctrl+X | Disconnect from broker |
 | Ctrl+S / Ctrl+Enter | Publish message |
 | Ctrl+Shift+Up / Ctrl+Shift+Down | Resize panels |
-| Ctrl+Up/Down or Ctrl+K/J | Scroll view |
-| Esc | Navigate back |
+
+## Navigation
+
+| Key | Action |
+| --- | ------ |
+| Esc | Back |
 | Tab / Shift+Tab | Cycle focus |
-| Up/Down or j/k | Move through lists |
+| Up/Down or j/k | Scroll view |
+| Left / Right | Switch pane |
 
 ## Broker Manager
 
@@ -32,7 +37,6 @@
 
 | Key | Action |
 | --- | ------ |
-| Left / Right | Switch pane |
 | Enter / Space | Toggle subscription |
 | p | Toggle publish highlight |
 | Delete | Delete topic |
@@ -67,14 +71,6 @@
 | Enter | Start or stop trace |
 | v | View trace messages |
 | Delete | Remove trace |
-| Ctrl+Shift+Up / Ctrl+Shift+Down | Resize panels |
-
-## Traces view
-
-| Key | Action |
-| --- | ------ |
-| Esc | Back |
-| Ctrl+Shift+Up / Ctrl+Shift+Down | Resize panels |
 
 ## Tips
 


### PR DESCRIPTION
## Summary
- consolidate navigation shortcuts into a dedicated table
- update README shortcuts to match key handler

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891f21419a08324b96a05f7d9a93f35