### PR TITLE
Embed history component for trace messages

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -119,7 +119,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	cs, loadErr := initConnections(conns)
 	st, _ := history.OpenStore("")
 	ms := initMessage()
-	tr, traceDel := traces.Init()
+	tr := traces.Init()
 	m := &model{
 		connections: cs,
 		ui:          initUI(order),
@@ -150,8 +150,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 		fitems[i] = m.focusables[id]
 	}
 	m.focus = focus.NewFocusMap(fitems)
-	traceDel.T = m.traces
-	m.traces.ViewList().SetDelegate(traceDel)
+	// history component handles its own delegate
 	// Register mode components so that view and update logic can be
 	// delegated based on the current application mode.
 	m.components = map[constants.AppMode]Component{

--- a/traces/init.go
+++ b/traces/init.go
@@ -6,15 +6,11 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 )
 
-// Init prepares the initial tracing state and message delegate.
-func Init() (State, MsgDelegate) {
+// Init prepares the initial tracing state.
+func Init() State {
 	traceList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	traceList.DisableQuitKeybindings()
 	traceList.SetShowTitle(false)
-	traceDel := MsgDelegate{}
-	traceView := list.New([]list.Item{}, traceDel, 0, 0)
-	traceView.DisableQuitKeybindings()
-	traceView.SetShowTitle(false)
 	tracesCfg := loadTraces()
 	var traceItems []list.Item
 	var traceData []*traceItem
@@ -33,7 +29,6 @@ func Init() (State, MsgDelegate) {
 		list:  traceList,
 		items: traceData,
 		form:  nil,
-		view:  traceView,
 	}
-	return ts, traceDel
+	return ts
 }

--- a/traces/model_traces.go
+++ b/traces/model_traces.go
@@ -2,12 +2,14 @@ package traces
 
 import (
 	"fmt"
-	connections "github.com/marang/emqutiti/connections"
 	"os"
 	"time"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+
+	connections "github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/history"
 )
 
 // forceStartTrace launches the tracer at index without checking existing data.
@@ -119,12 +121,16 @@ func (t *Component) loadTraceMessages(index int) {
 		t.api.LogHistory("", err.Error(), "log", err.Error())
 		return
 	}
-	items := make([]list.Item, len(msgs))
+	histItems := make([]history.Item, len(msgs))
+	listItems := make([]list.Item, len(msgs))
 	for i, mmsg := range msgs {
-		items[i] = traceMsgItem{idx: i + 1, msg: mmsg}
+		hi := history.Item{Timestamp: mmsg.Timestamp, Topic: mmsg.Topic, Payload: mmsg.Payload, Kind: mmsg.Kind}
+		histItems[i] = hi
+		listItems[i] = hi
 	}
-	t.view.SetItems(items)
-	t.view.SetSize(t.api.Width()-4, t.api.TraceHeight())
+	t.Component.SetItems(histItems)
+	t.Component.List().SetItems(listItems)
+	t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
 	t.viewKey = it.key
 	_ = t.api.SetModeViewTrace()
 }

--- a/traces/view_messages.go
+++ b/traces/view_messages.go
@@ -11,7 +11,7 @@ import (
 func (t *Component) ViewMessages() string {
 	t.api.ResetElemPos()
 	title := fmt.Sprintf("Trace %s", t.viewKey)
-	listLines := strings.Split(t.view.View(), "\n")
+	listLines := strings.Split(t.Component.List().View(), "\n")
 	help := ui.InfoStyle.Render("[esc] back")
 	listLines = append(listLines, help)
 	target := len(listLines)


### PR DESCRIPTION
## Summary
- embed history.Component into traces to reuse history list rendering
- adapt trace message loading to populate history items
- view and update functions delegate to history component, removing custom delegate

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fc0a9f348324a9085fc21687a518