### PR TITLE
traces: fill screen in message view

### DIFF
--- a/traces/component.go
+++ b/traces/component.go
@@ -114,7 +114,7 @@ func (h *histModel) SetFocus(id string) tea.Cmd { return h.api.SetFocus(id) }
 
 func (h *histModel) Width() int { return h.api.Width() }
 
-func (h *histModel) Height() int { return h.api.TraceHeight() }
+func (h *histModel) Height() int { return h.api.Height() }
 
 func (h *histModel) OverlayHelp(v string) string { return h.api.OverlayHelp(v) }
 
@@ -207,14 +207,6 @@ func (t *Component) Update(msg tea.Msg) tea.Cmd {
 				return traceTicker()
 			}
 			return nil
-		case "ctrl+shift+up":
-			if t.api.TraceHeight() > 1 {
-				t.api.SetTraceHeight(t.api.TraceHeight() - 1)
-				t.list.SetSize(t.api.Width()-4, t.api.Height()-4)
-			}
-		case "ctrl+shift+down":
-			t.api.SetTraceHeight(t.api.TraceHeight() + 1)
-			t.list.SetSize(t.api.Width()-4, t.api.Height()-4)
 		}
 	}
 	t.list, cmd = t.list.Update(msg)
@@ -303,16 +295,6 @@ func (t *Component) UpdateView(msg tea.Msg) tea.Cmd {
 			return t.api.SetModeTracer()
 		case "ctrl+d":
 			return tea.Quit
-		case "ctrl+shift+up":
-			if t.api.TraceHeight() > 1 {
-				t.api.SetTraceHeight(t.api.TraceHeight() - 1)
-				t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
-			}
-			return nil
-		case "ctrl+shift+down":
-			t.api.SetTraceHeight(t.api.TraceHeight() + 1)
-			t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
-			return nil
 		}
 	}
 	return t.Component.Update(msg)

--- a/traces/model_traces.go
+++ b/traces/model_traces.go
@@ -130,7 +130,7 @@ func (t *Component) loadTraceMessages(index int) {
 	}
 	t.Component.SetItems(histItems)
 	t.Component.List().SetItems(listItems)
-	t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
+	t.Component.List().SetSize(t.api.Width()-4, t.api.Height()-4)
 	t.viewKey = it.key
 	_ = t.api.SetModeViewTrace()
 }

--- a/traces/view_messages.go
+++ b/traces/view_messages.go
@@ -14,15 +14,7 @@ func (t *Component) ViewMessages() string {
 	listLines := strings.Split(t.Component.List().View(), "\n")
 	help := ui.InfoStyle.Render("[esc] back")
 	listLines = append(listLines, help)
-	target := len(listLines)
-	minHeight := t.api.TraceHeight() + 1
-	if target < minHeight {
-		for len(listLines) < minHeight {
-			listLines = append(listLines, "")
-		}
-		target = minHeight
-	}
 	content := strings.Join(listLines, "\n")
-	view := ui.LegendBox(content, title, t.api.Width()-2, target, ui.ColBlue, true, -1)
+	view := ui.LegendBox(content, title, t.api.Width()-2, t.api.Height()-2, ui.ColBlue, true, -1)
 	return t.api.OverlayHelp(view)
 }


### PR DESCRIPTION
## Summary
- size trace message list using full window height
- drop manual height shortcuts
- render message pane with dynamic height

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891ff7fb2648324a02f7b37c15aa85b