### PR TITLE
fix: focus trace form to save on enter

### DIFF
--- a/model.go
+++ b/model.go
@@ -96,7 +96,7 @@ type uiState struct {
 	viewport   viewport.Model      // scrolling container for the main view
 	elemPos    map[string]int      // cached Y positions of each box
 	focusOrder []string            // order of focusable elements
-	focusMap   map[string]int // maps element IDs to their index
+	focusMap   map[string]int      // maps element IDs to their index
 }
 
 type model struct {
@@ -132,5 +132,6 @@ func (m *model) Focusables() map[string]focus.Focusable {
 		idTopics:      &focus.NullFocusable{},
 		idHistory:     &focus.NullFocusable{},
 		traces.IDList: &focus.NullFocusable{},
+		traces.IDForm: &focus.NullFocusable{},
 	}
 }

--- a/model_base.go
+++ b/model_base.go
@@ -27,7 +27,7 @@ var focusByMode = map[constants.AppMode][]string{
 	constants.ModeTopics:         {idTopicsSubscribed, idTopicsUnsubscribed, idHelp},
 	constants.ModePayloads:       {idPayloadList, idHelp},
 	constants.ModeTracer:         {traces.IDList, idHelp},
-	constants.ModeEditTrace:      {idHelp},
+	constants.ModeEditTrace:      {traces.IDForm, idHelp},
 	constants.ModeViewTrace:      {idHelp},
 	constants.ModeImporter:       {idHelp},
 	constants.ModeHistoryFilter:  {idHelp},

--- a/traces/api.go
+++ b/traces/api.go
@@ -9,6 +9,9 @@ import (
 // IDList identifies the trace list focusable element.
 const IDList = "trace-list"
 
+// IDForm identifies the trace form focusable element.
+const IDForm = "trace-form"
+
 // API defines interactions required by the traces component from the host model.
 type API interface {
 	confirm.API

--- a/traces/component.go
+++ b/traces/component.go
@@ -132,7 +132,7 @@ func (t *Component) Focus() tea.Cmd { return nil }
 
 func (t *Component) Blur() {}
 
-// Focusables satisfies FocusableSet; the base model provides the trace list focusable.
+// Focusables satisfies FocusableSet; the base model provides trace focusables.
 func (t *Component) Focusables() map[string]focus.Focusable { return map[string]focus.Focusable{} }
 
 // List exposes the trace configuration list model.


### PR DESCRIPTION
## Summary
- make trace form focusable so Enter saves instead of opening help

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fb0db7cc8324ad111f4d30ff6efb