### PR TITLE
fix: focus trace form to save on enter

### DIFF
--- a/model.go
+++ b/model.go
@@ -96,7 +96,7 @@ type uiState struct {
 	viewport   viewport.Model      // scrolling container for the main view
 	elemPos    map[string]int      // cached Y positions of each box
 	focusOrder []string            // order of focusable elements
-	focusMap   map[string]int // maps element IDs to their index
+	focusMap   map[string]int      // maps element IDs to their index
 }
 
 type model struct {
@@ -132,5 +132,6 @@ func (m *model) Focusables() map[string]focus.Focusable {
 		idTopics:      &focus.NullFocusable{},
 		idHistory:     &focus.NullFocusable{},
 		traces.IDList: &focus.NullFocusable{},
+		traces.IDForm: &focus.NullFocusable{},
 	}
 }

--- a/model_base.go
+++ b/model_base.go
@@ -27,7 +27,7 @@ var focusByMode = map[constants.AppMode][]string{
 	constants.ModeTopics:         {idTopicsSubscribed, idTopicsUnsubscribed, idHelp},
 	constants.ModePayloads:       {idPayloadList, idHelp},
 	constants.ModeTracer:         {traces.IDList, idHelp},
-	constants.ModeEditTrace:      {idHelp},
+	constants.ModeEditTrace:      {traces.IDForm, idHelp},
 	constants.ModeViewTrace:      {idHelp},
 	constants.ModeImporter:       {idHelp},
 	constants.ModeHistoryFilter:  {idHelp},

--- a/traces/api.go
+++ b/traces/api.go
@@ -9,6 +9,9 @@ import (
 // IDList identifies the trace list focusable element.
 const IDList = "trace-list"
 
+// IDForm identifies the trace form focusable element.
+const IDForm = "trace-form"
+
 // API defines interactions required by the traces component from the host model.
 type API interface {
 	confirm.API

--- a/traces/component.go
+++ b/traces/component.go
@@ -132,7 +132,7 @@ func (t *Component) Focus() tea.Cmd { return nil }
 
 func (t *Component) Blur() {}
 
-// Focusables satisfies FocusableSet; the base model provides the trace list focusable.
+// Focusables satisfies FocusableSet; the base model provides trace focusables.
 func (t *Component) Focusables() map[string]focus.Focusable { return map[string]focus.Focusable{} }
 
 // List exposes the trace configuration list model.
@@ -171,7 +171,11 @@ func (t *Component) Update(msg tea.Msg) tea.Cmd {
 			topics := t.api.SubscribedTopics()
 			f := newTraceForm(opts, t.api.ActiveConnection(), topics)
 			t.form = &f
-			return tea.Batch(t.api.SetModeEditTrace(), textinput.Blink)
+			return tea.Batch(
+				t.api.SetModeEditTrace(),
+				t.api.SetFocus(IDForm),
+				textinput.Blink,
+			)
 		case "enter":
 			i := t.list.Index()
 			if i >= 0 && i < len(t.items) {

--- a/traces/component.go
+++ b/traces/component.go
@@ -195,20 +195,35 @@ func (t *Component) Update(msg tea.Msg) tea.Cmd {
 		case "delete":
 			i := t.list.Index()
 			if i >= 0 && i < len(t.items) {
-				key := t.items[i].key
-				t.stopTrace(i)
-				t.items = append(t.items[:i], t.items[i+1:]...)
-				items := []list.Item{}
-				for _, it := range t.items {
-					items = append(items, it)
-				}
-				t.list.SetItems(items)
-				if err := removeTrace(key); err != nil {
-					t.api.LogHistory("", err.Error(), "log", err.Error())
-				}
-			}
-			if t.anyTraceRunning() {
-				return traceTicker()
+				it := t.items[i]
+				key := it.key
+				cfg := it.cfg
+				rf := func() tea.Cmd { return t.api.SetFocus(t.api.FocusedID()) }
+				t.api.StartConfirm(
+					fmt.Sprintf("Delete trace '%s'? [y/n]", key),
+					"this also removes all stored data from the Badger DB",
+					rf,
+					func() tea.Cmd {
+						t.stopTrace(i)
+						t.items = append(t.items[:i], t.items[i+1:]...)
+						items := make([]list.Item, len(t.items))
+						for idx, itm := range t.items {
+							items[idx] = itm
+						}
+						t.list.SetItems(items)
+						if err := t.store.RemoveTrace(key); err != nil {
+							t.api.LogHistory("", err.Error(), "log", err.Error())
+						}
+						if err := t.store.ClearData(cfg.Profile, key); err != nil {
+							t.api.LogHistory("", err.Error(), "log", err.Error())
+						}
+						if t.anyTraceRunning() {
+							return traceTicker()
+						}
+						return nil
+					},
+					nil,
+				)
 			}
 			return nil
 		case "ctrl+shift+up":
@@ -233,16 +248,18 @@ func (t *Component) UpdateForm(msg tea.Msg) tea.Cmd {
 	if t.form == nil {
 		return nil
 	}
-	var cmd tea.Cmd
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
+	if km, ok := msg.(tea.KeyMsg); ok {
+		switch km.String() {
 		case "ctrl+d":
 			return tea.Quit
 		case "esc":
 			t.form = nil
 			return t.api.SetModeTracer()
-		case "enter":
+		}
+		if t.api.FocusedID() != IDForm {
+			return nil
+		}
+		if km.String() == "enter" {
 			cfg := t.form.Config()
 			if cfg.Key == "" || len(cfg.Topics) == 0 || cfg.Profile == "" {
 				t.form.errMsg = "key, profile and topics required"
@@ -292,7 +309,10 @@ func (t *Component) UpdateForm(msg tea.Msg) tea.Cmd {
 			t.form = nil
 			return t.api.SetModeTracer()
 		}
+	} else if t.api.FocusedID() != IDForm {
+		return nil
 	}
+	var cmd tea.Cmd
 	f, cmd := t.form.Update(msg)
 	t.form = &f
 	return cmd

--- a/traces/component.go
+++ b/traces/component.go
@@ -201,7 +201,7 @@ func (t *Component) Update(msg tea.Msg) tea.Cmd {
 				rf := func() tea.Cmd { return t.api.SetFocus(t.api.FocusedID()) }
 				t.api.StartConfirm(
 					fmt.Sprintf("Delete trace '%s'? [y/n]", key),
-					"this also removes all stored data from the Badger DB",
+					"This also removes all stored data of this trace",
 					rf,
 					func() tea.Cmd {
 						t.stopTrace(i)

--- a/traces/view_form.go
+++ b/traces/view_form.go
@@ -7,7 +7,17 @@ import (
 // ViewForm renders the form for new traces.
 func (t *Component) ViewForm() string {
 	t.api.ResetElemPos()
+	focused := t.api.FocusedID() == IDForm
+	if t.form != nil {
+		if focused {
+			t.form.ApplyFocus()
+		} else {
+			for _, fld := range t.form.Fields {
+				fld.Blur()
+			}
+		}
+	}
 	content := t.form.View()
-	view := ui.LegendBox(content, "New Trace", t.api.Width()-2, 0, ui.ColBlue, true, -1)
+	view := ui.LegendBox(content, "New Trace", t.api.Width()-2, 0, ui.ColBlue, focused, -1)
 	return t.api.OverlayHelp(view)
 }


### PR DESCRIPTION
## Summary
- make trace form focusable so Enter saves instead of opening help
- focus the trace form when opening a new trace

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6891fb0db7cc8324ad111f4d30ff6efb