### PR TITLE
traces: reuse history filter and fix resizing

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -13,6 +13,7 @@ const (
 	ModeTracer
 	ModeEditTrace
 	ModeViewTrace
+	ModeTraceFilter
 	ModeImporter
 	ModeHistoryFilter
 	ModeHistoryDetail

--- a/model_base.go
+++ b/model_base.go
@@ -29,6 +29,7 @@ var focusByMode = map[constants.AppMode][]string{
 	constants.ModeTracer:         {traces.IDList, idHelp},
 	constants.ModeEditTrace:      {traces.IDForm, idHelp},
 	constants.ModeViewTrace:      {idHelp},
+	constants.ModeTraceFilter:    {idHelp},
 	constants.ModeImporter:       {idHelp},
 	constants.ModeHistoryFilter:  {idHelp},
 	constants.ModeHistoryDetail:  {idHelp},

--- a/model_init.go
+++ b/model_init.go
@@ -163,6 +163,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 		constants.ModeTracer:         tracesComp,
 		constants.ModeEditTrace:      component{update: m.traces.UpdateForm, view: m.traces.ViewForm},
 		constants.ModeViewTrace:      component{update: m.traces.UpdateView, view: m.traces.ViewMessages},
+		constants.ModeTraceFilter:    component{update: m.traces.UpdateFilter, view: m.traces.ViewFilter},
 		constants.ModeHistoryFilter:  component{update: m.history.UpdateFilter, view: m.history.ViewFilter},
 		constants.ModeHistoryDetail:  component{update: m.history.UpdateDetail, view: m.history.ViewDetail},
 		constants.ModeHelp:           m.help,

--- a/traces/api.go
+++ b/traces/api.go
@@ -19,6 +19,7 @@ type API interface {
 	SetModeTracer() tea.Cmd
 	SetModeEditTrace() tea.Cmd
 	SetModeViewTrace() tea.Cmd
+	SetModeTraceFilter() tea.Cmd
 	SetFocus(id string) tea.Cmd
 	FocusedID() string
 	ResetElemPos()

--- a/traces/history_mem_store.go
+++ b/traces/history_mem_store.go
@@ -1,0 +1,67 @@
+package traces
+
+import (
+	"strings"
+	"time"
+
+	"github.com/marang/emqutiti/history"
+)
+
+type memStore struct {
+	msgs []history.Message
+}
+
+func newMemStore(msgs []history.Message) *memStore {
+	return &memStore{msgs: msgs}
+}
+
+func (m *memStore) Append(history.Message) {}
+
+func (m *memStore) Search(archived bool, topics []string, start, end time.Time, payload string) []history.Message {
+	var out []history.Message
+	topicSet := map[string]struct{}{}
+	for _, t := range topics {
+		if t != "" {
+			topicSet[t] = struct{}{}
+		}
+	}
+	for _, msg := range m.msgs {
+		if msg.Archived != archived {
+			continue
+		}
+		if len(topicSet) > 0 {
+			if _, ok := topicSet[msg.Topic]; !ok {
+				continue
+			}
+		}
+		if !start.IsZero() && msg.Timestamp.Before(start) {
+			continue
+		}
+		if !end.IsZero() && msg.Timestamp.After(end) {
+			continue
+		}
+		if payload != "" && !strings.Contains(msg.Payload, payload) {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func (m *memStore) Delete(string) error { return nil }
+
+func (m *memStore) Archive(string) error { return nil }
+
+func (m *memStore) Count(archived bool) int {
+	c := 0
+	for _, msg := range m.msgs {
+		if msg.Archived == archived {
+			c++
+		}
+	}
+	return c
+}
+
+func (m *memStore) Close() error { return nil }
+
+var _ history.Store = (*memStore)(nil)

--- a/traces/model_traces.go
+++ b/traces/model_traces.go
@@ -123,14 +123,17 @@ func (t *Component) loadTraceMessages(index int) {
 	}
 	histItems := make([]history.Item, len(msgs))
 	listItems := make([]list.Item, len(msgs))
+	hmsgs := make([]history.Message, len(msgs))
 	for i, mmsg := range msgs {
 		hi := history.Item{Timestamp: mmsg.Timestamp, Topic: mmsg.Topic, Payload: mmsg.Payload, Kind: mmsg.Kind}
 		histItems[i] = hi
 		listItems[i] = hi
+		hmsgs[i] = history.Message{Timestamp: mmsg.Timestamp, Topic: mmsg.Topic, Payload: mmsg.Payload, Kind: mmsg.Kind, Archived: false}
 	}
 	t.Component.SetItems(histItems)
 	t.Component.List().SetItems(listItems)
-	t.Component.List().SetSize(t.api.Width()-4, t.api.Height()-4)
+	t.Component.SetStore(newMemStore(hmsgs))
+	t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
 	t.viewKey = it.key
 	_ = t.api.SetModeViewTrace()
 }

--- a/traces/view_messages.go
+++ b/traces/view_messages.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/marang/emqutiti/ui"
 )
 
@@ -11,10 +12,21 @@ import (
 func (t *Component) ViewMessages() string {
 	t.api.ResetElemPos()
 	title := fmt.Sprintf("Trace %s", t.viewKey)
+	if t.FilterQuery() != "" {
+		t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight()-1)
+	} else {
+		t.Component.List().SetSize(t.api.Width()-4, t.api.TraceHeight())
+	}
 	listLines := strings.Split(t.Component.List().View(), "\n")
+	if t.FilterQuery() != "" {
+		inner := t.api.Width() - 4
+		filterLine := fmt.Sprintf("Filters: %s", t.FilterQuery())
+		filterLine = ansi.Truncate(filterLine, inner, "")
+		listLines = append([]string{filterLine}, listLines...)
+	}
 	help := ui.InfoStyle.Render("[esc] back")
 	listLines = append(listLines, help)
 	content := strings.Join(listLines, "\n")
-	view := ui.LegendBox(content, title, t.api.Width()-2, t.api.Height()-2, ui.ColBlue, true, -1)
+	view := ui.LegendBox(content, title, t.api.Width()-2, t.api.TraceHeight(), ui.ColBlue, true, -1)
 	return t.api.OverlayHelp(view)
 }

--- a/traces_api_impl.go
+++ b/traces_api_impl.go
@@ -10,10 +10,11 @@ import (
 
 func (m *model) tracesStore() traces.Store { return traces.FileStore{} }
 
-func (m *model) SetModeClient() tea.Cmd    { return m.SetMode(constants.ModeClient) }
-func (m *model) SetModeTracer() tea.Cmd    { return m.SetMode(constants.ModeTracer) }
-func (m *model) SetModeEditTrace() tea.Cmd { return m.SetMode(constants.ModeEditTrace) }
-func (m *model) SetModeViewTrace() tea.Cmd { return m.SetMode(constants.ModeViewTrace) }
+func (m *model) SetModeClient() tea.Cmd      { return m.SetMode(constants.ModeClient) }
+func (m *model) SetModeTracer() tea.Cmd      { return m.SetMode(constants.ModeTracer) }
+func (m *model) SetModeEditTrace() tea.Cmd   { return m.SetMode(constants.ModeEditTrace) }
+func (m *model) SetModeViewTrace() tea.Cmd   { return m.SetMode(constants.ModeViewTrace) }
+func (m *model) SetModeTraceFilter() tea.Cmd { return m.SetMode(constants.ModeTraceFilter) }
 
 func (m *model) Profiles() []connections.Profile { return m.connections.Manager.Profiles }
 


### PR DESCRIPTION
## Summary
- support `ModeTraceFilter` and wire traces view into mode and focus maps
- enable history-style filtering for trace messages with a lightweight in-memory store
- resize trace message view correctly when using Ctrl+Shift+Arrow

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68921c0ce5fc8324af3d26ae6367cdf0