### PR TITLE
Add mqtt and mqtts schema options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ password = "keyring:emqutiti-local/user"
 ```
 
 Tips:
+- `schema` can be `mqtt`, `mqtts`, `tcp`, `ssl`, `ws`, or `wss`.
 - More options like TLS and session settings are available; see the `config` package for details.
 - Set `random_id_suffix = true` for unique client IDs.
 - Set `skip_tls_verify = true` to bypass TLS certificate checks (useful for self-signed brokers).

--- a/connections/form.go
+++ b/connections/form.go
@@ -37,7 +37,7 @@ type fieldDef struct {
 
 var formFields = []fieldDef{
 	{key: "Name", label: "Name", placeholder: "Name", fieldType: ftText},
-	{key: "Schema", label: "Schema", placeholder: "Schema", fieldType: ftSelect, options: []string{"tcp", "ssl", "ws", "wss"}},
+	{key: "Schema", label: "Schema", placeholder: "Schema", fieldType: ftSelect, options: []string{"tcp", "ssl", "ws", "wss", "mqtt", "mqtts"}},
 	{key: "Host", label: "Host", placeholder: "Host", fieldType: ftText},
 	{key: "Port", label: "Port", placeholder: "Port", fieldType: ftText},
 	{key: "ClientID", label: "Client ID", placeholder: "Client ID", fieldType: ftText},

--- a/connections/form_test.go
+++ b/connections/form_test.go
@@ -84,3 +84,16 @@ func TestConnectionFormProfileInvalidInt(t *testing.T) {
 		t.Fatalf("expected port 0, got %d", p.Port)
 	}
 }
+
+func TestConnectionFormSchemaOptions(t *testing.T) {
+	cf := NewForm(Profile{Schema: "mqtt"}, -1)
+	sf := cf.Fields[fieldIndex["Schema"]].(*ui.SelectField)
+	if sf.Value() != "mqtt" {
+		t.Fatalf("expected schema mqtt, got %s", sf.Value())
+	}
+	cf = NewForm(Profile{Schema: "mqtts"}, -1)
+	sf = cf.Fields[fieldIndex["Schema"]].(*ui.SelectField)
+	if sf.Value() != "mqtts" {
+		t.Fatalf("expected schema mqtts, got %s", sf.Value())
+	}
+}

--- a/connections/profile_test.go
+++ b/connections/profile_test.go
@@ -14,9 +14,12 @@ import (
 )
 
 func TestProfileBrokerURL(t *testing.T) {
-	p := Profile{Schema: "mqtt", Host: "example.com", Port: 1883}
-	if got := p.BrokerURL(); got != "mqtt://example.com:1883" {
-		t.Fatalf("BrokerURL() = %q", got)
+	for _, schema := range []string{"mqtt", "mqtts"} {
+		p := Profile{Schema: schema, Host: "example.com", Port: 1883}
+		want := schema + "://example.com:1883"
+		if got := p.BrokerURL(); got != want {
+			t.Fatalf("BrokerURL() = %q", got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- allow choosing mqtt and mqtts schemas for broker profiles
- test schema selection and broker URL helper
- document supported schema values

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68930a8188648324a702f15b65093dce