### PR TITLE
handle j/k as text in forms

### DIFF
--- a/ui/form_suggest.go
+++ b/ui/form_suggest.go
@@ -99,6 +99,6 @@ func (s *SuggestField) WantsKey(k tea.KeyMsg) bool {
 	case "tab", "shift+tab", "up", "down", "enter", " ", "space":
 		return len(s.suggestions) > 0
 	default:
-		return false
+		return s.TextField.WantsKey(k)
 	}
 }

--- a/ui/form_text.go
+++ b/ui/form_text.go
@@ -50,3 +50,15 @@ func (t *TextField) Value() string { return t.Model.Value() }
 func (t *TextField) Focus()       { t.Model.Focus() }
 func (t *TextField) Blur()        { t.Model.Blur() }
 func (t *TextField) View() string { return t.Model.View() }
+
+// WantsKey reports whether the field wants to handle navigation keys itself
+// instead of letting the form cycle focus. Plain "j" and "k" are treated as
+// normal input so users can type them without jumping to another field.
+func (t *TextField) WantsKey(k tea.KeyMsg) bool {
+	switch k.String() {
+	case "j", "k":
+		return true
+	default:
+		return false
+	}
+}

--- a/ui/form_text_test.go
+++ b/ui/form_text_test.go
@@ -1,0 +1,48 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Test that plain j/k are consumed by TextField and do not move focus.
+func TestTextFieldConsumesJK(t *testing.T) {
+	tf1 := NewTextField("", "")
+	tf2 := NewTextField("", "")
+	f := Form{Fields: []Field{tf1, tf2}, Focus: 0}
+	f.ApplyFocus()
+
+	for _, tt := range []struct{ r rune }{{'j'}, {'k'}} {
+		key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{tt.r}}
+		f.CycleFocus(key)
+		f.ApplyFocus()
+		f.Fields[f.Focus].Update(key)
+		if f.Focus != 0 {
+			t.Fatalf("focus moved on %q", string(tt.r))
+		}
+		if tf1.Value() != string(tt.r) {
+			t.Fatalf("field value=%q want=%q", tf1.Value(), string(tt.r))
+		}
+		tf1.SetValue("")
+	}
+}
+
+// Test that SuggestField also consumes j/k without losing focus.
+func TestSuggestFieldConsumesJK(t *testing.T) {
+	sf := NewSuggestField([]string{"foo"}, "topic")
+	tf := NewTextField("", "")
+	f := Form{Fields: []Field{sf, tf}, Focus: 0}
+	f.ApplyFocus()
+
+	key := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}
+	f.CycleFocus(key)
+	f.ApplyFocus()
+	f.Fields[f.Focus].Update(key)
+	if f.Focus != 0 {
+		t.Fatalf("focus moved on j")
+	}
+	if sf.Value() != "j" {
+		t.Fatalf("field value=%q want=j", sf.Value())
+	}
+}


### PR DESCRIPTION
## Summary
- consume plain j/k in text fields so they don't jump focus
- ensure suggest fields also defer j/k to text field handling
- add tests proving j/k keeps focus in place

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893138ecba083249bcb4082be0678fa