### PR TITLE
Handle empty action in logTopicAction

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -13,6 +13,9 @@ import (
 // logTopicAction appends a log entry for a topic action.
 // action should be "subscribe" or "unsubscribe".
 func (m *model) logTopicAction(topic, action string, err error) {
+	if len(action) == 0 {
+		return
+	}
 	act := strings.ToUpper(action[:1]) + action[1:]
 	if err != nil {
 		m.history.Append(topic, "", "log", fmt.Sprintf("%s error for %s: %v", act, topic, err))

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -138,3 +138,45 @@ func TestHandleTopicToggleUnsubscribeError(t *testing.T) {
 		t.Fatalf("expected log with error, got kind %q payload %q", items[0].Kind, items[0].Payload)
 	}
 }
+
+// Test logTopicAction handles empty and valid actions.
+func TestLogTopicAction(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		m, _ := initialModel(nil)
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("logTopicAction panicked: %v", r)
+				}
+			}()
+			m.logTopicAction("t1", "", nil)
+		}()
+		if len(m.history.Items()) != 0 {
+			t.Fatalf("expected no history items, got %d", len(m.history.Items()))
+		}
+	})
+
+	t.Run("subscribe", func(t *testing.T) {
+		m, _ := initialModel(nil)
+		m.logTopicAction("t1", "subscribe", nil)
+		items := m.history.Items()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 history item, got %d", len(items))
+		}
+		if items[0].Kind != "log" || items[0].Payload != "Subscribed to topic: t1" {
+			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
+		}
+	})
+
+	t.Run("unsubscribe", func(t *testing.T) {
+		m, _ := initialModel(nil)
+		m.logTopicAction("t1", "unsubscribe", nil)
+		items := m.history.Items()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 history item, got %d", len(items))
+		}
+		if items[0].Kind != "log" || items[0].Payload != "Unsubscribed from topic: t1" {
+			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- guard against empty action in logTopicAction
- test logTopicAction with empty, subscribe, and unsubscribe actions

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689332012a2483248b9d5e14e1c52b7a