### PR TITLE
Close message channel on disconnect

### DIFF
--- a/mqttclient.go
+++ b/mqttclient.go
@@ -16,7 +16,10 @@ type MQTTMessage struct {
 }
 
 type MQTTClient struct {
-	Client      mqtt.Client
+	Client mqtt.Client
+	// MessageChan receives published messages. It is closed when
+	// Disconnect is called, so consumers must handle channel
+	// closure.
 	MessageChan chan MQTTMessage
 }
 
@@ -123,10 +126,15 @@ func (m *MQTTClient) Unsubscribe(topic string) error {
 	return nil
 }
 
-// Disconnect cleanly closes the connection to the broker.
+// Disconnect cleanly closes the connection to the broker and closes
+// MessageChan. Consumers must handle channel closure.
 func (m *MQTTClient) Disconnect() {
 	if m.Client != nil && m.Client.IsConnected() {
 		// Allow up to 250 milliseconds for pending work to complete.
 		m.Client.Disconnect(250)
+	}
+	if m.MessageChan != nil {
+		close(m.MessageChan)
+		m.MessageChan = nil
 	}
 }

--- a/mqttclient_test.go
+++ b/mqttclient_test.go
@@ -1,0 +1,12 @@
+package emqutiti
+
+import "testing"
+
+func TestDisconnectClosesMessageChan(t *testing.T) {
+	ch := make(chan MQTTMessage)
+	c := &MQTTClient{MessageChan: ch}
+	c.Disconnect()
+	if _, ok := <-ch; ok {
+		t.Fatalf("expected MessageChan to be closed")
+	}
+}


### PR DESCRIPTION
## Summary
- Close `MessageChan` when disconnecting the MQTT client
- Document channel closure so consumers handle it
- Add unit test for message channel closure

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934cdbc43c83249244741d83a40522