### PR TITLE
Add operation timeouts to MQTT client

### DIFF
--- a/connections/profile.go
+++ b/connections/profile.go
@@ -25,6 +25,9 @@ type Profile struct {
 	QoS                 int    `toml:"qos" env:"qos"`
 	AutoReconnect       bool   `toml:"auto_reconnect" env:"auto_reconnect"`
 	ReconnectPeriod     int    `toml:"reconnect_period" env:"reconnect_period"`
+	PublishTimeout      int    `toml:"publish_timeout" env:"publish_timeout"`
+	SubscribeTimeout    int    `toml:"subscribe_timeout" env:"subscribe_timeout"`
+	UnsubscribeTimeout  int    `toml:"unsubscribe_timeout" env:"unsubscribe_timeout"`
 	CleanStart          bool   `toml:"clean_start" env:"clean_start"`
 	SessionExpiry       int    `toml:"session_expiry_interval" env:"session_expiry_interval"`
 	ReceiveMaximum      int    `toml:"receive_maximum" env:"receive_maximum"`

--- a/connections/profile_env.go
+++ b/connections/profile_env.go
@@ -73,6 +73,21 @@ var profileEnvSetters = map[string]profileEnvSetter{
 			p.ReconnectPeriod = iv
 		}
 	},
+	"publish_timeout": func(p *Profile, v string) {
+		if iv, err := strconv.Atoi(v); err == nil {
+			p.PublishTimeout = iv
+		}
+	},
+	"subscribe_timeout": func(p *Profile, v string) {
+		if iv, err := strconv.Atoi(v); err == nil {
+			p.SubscribeTimeout = iv
+		}
+	},
+	"unsubscribe_timeout": func(p *Profile, v string) {
+		if iv, err := strconv.Atoi(v); err == nil {
+			p.UnsubscribeTimeout = iv
+		}
+	},
 	"clean_start": func(p *Profile, v string) {
 		if bv, err := strconv.ParseBool(v); err == nil {
 			p.CleanStart = bv

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -10,14 +10,19 @@ import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
 
+const defaultTokenTimeout = 5 * time.Second
+
 type MQTTMessage struct {
 	Topic   string
 	Payload string
 }
 
 type MQTTClient struct {
-	Client      mqtt.Client
-	MessageChan chan MQTTMessage
+	Client             mqtt.Client
+	MessageChan        chan MQTTMessage
+	publishTimeout     time.Duration
+	subscribeTimeout   time.Duration
+	unsubscribeTimeout time.Duration
 }
 
 // NewMQTTClient creates and configures a new MQTT client based on the profile
@@ -85,7 +90,17 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 		return nil, fmt.Errorf("failed to connect: %w", token.Error())
 	}
 
-	return &MQTTClient{Client: client, MessageChan: msgChan}, nil
+	pubTimeout := time.Duration(p.PublishTimeout) * time.Second
+	subTimeout := time.Duration(p.SubscribeTimeout) * time.Second
+	unsubTimeout := time.Duration(p.UnsubscribeTimeout) * time.Second
+
+	return &MQTTClient{
+		Client:             client,
+		MessageChan:        msgChan,
+		publishTimeout:     pubTimeout,
+		subscribeTimeout:   subTimeout,
+		unsubscribeTimeout: unsubTimeout,
+	}, nil
 }
 
 // Publish sends the payload to the given topic using the underlying client.
@@ -93,7 +108,13 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 // broker.
 func (m *MQTTClient) Publish(topic string, qos byte, retained bool, payload interface{}) error {
 	token := m.Client.Publish(topic, qos, retained, payload)
-	token.Wait()
+	timeout := m.publishTimeout
+	if timeout <= 0 {
+		timeout = defaultTokenTimeout
+	}
+	if !token.WaitTimeout(timeout) {
+		return fmt.Errorf("publish timeout after %v", timeout)
+	}
 	if token.Error() != nil {
 		return fmt.Errorf("publish failed: %w", token.Error())
 	}
@@ -105,7 +126,13 @@ func (m *MQTTClient) Publish(topic string, qos byte, retained bool, payload inte
 // returns an error if the request fails.
 func (m *MQTTClient) Subscribe(topic string, qos byte, callback mqtt.MessageHandler) error {
 	token := m.Client.Subscribe(topic, qos, callback)
-	token.Wait()
+	timeout := m.subscribeTimeout
+	if timeout <= 0 {
+		timeout = defaultTokenTimeout
+	}
+	if !token.WaitTimeout(timeout) {
+		return fmt.Errorf("subscribe timeout after %v", timeout)
+	}
 	if token.Error() != nil {
 		return fmt.Errorf("subscribe failed: %w", token.Error())
 	}
@@ -116,7 +143,13 @@ func (m *MQTTClient) Subscribe(topic string, qos byte, callback mqtt.MessageHand
 // completion and returns an error if the unsubscribe request fails.
 func (m *MQTTClient) Unsubscribe(topic string) error {
 	token := m.Client.Unsubscribe(topic)
-	token.Wait()
+	timeout := m.unsubscribeTimeout
+	if timeout <= 0 {
+		timeout = defaultTokenTimeout
+	}
+	if !token.WaitTimeout(timeout) {
+		return fmt.Errorf("unsubscribe timeout after %v", timeout)
+	}
 	if token.Error() != nil {
 		return fmt.Errorf("unsubscribe failed: %w", token.Error())
 	}


### PR DESCRIPTION
## Summary
- add publish/subscribe/unsubscribe timeout fields to connection profiles
- wait for MQTT operations using token timeouts

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934cf012888324b85fd49aa723b3dc