### PR TITLE
refactor: centralize window size calculations

### DIFF
--- a/update_helpers.go
+++ b/update_helpers.go
@@ -6,33 +6,86 @@ import (
 	"github.com/marang/emqutiti/constants"
 )
 
+// calcHistorySize returns the width and height for the history list.
+// It defaults the height when the current value is zero.
+func calcHistorySize(width, height, currentHeight int) (int, int) {
+	if currentHeight == 0 {
+		currentHeight = (height-1)/3 + 10
+	}
+	return width - 4, currentHeight
+}
+
+// calcMessageWidth returns the width for message inputs and lists.
+func calcMessageWidth(width int) int {
+	return width - 4
+}
+
+// calcConnectionsSize returns the width and height for the connections list.
+func calcConnectionsSize(width, height int) (int, int) {
+	return width - 4, height - 6
+}
+
+// calcTopicsInputWidth returns the width for the topics input.
+func calcTopicsInputWidth(width int) int {
+	return width - 7
+}
+
+// calcTraceHeight returns the height for trace views, defaulting if zero.
+func calcTraceHeight(height, currentHeight int) int {
+	if currentHeight == 0 {
+		return height - 6
+	}
+	return currentHeight
+}
+
+// calcTraceListSize returns size for trace lists.
+func calcTraceListSize(width, height int) (int, int) {
+	return width - 4, height - 4
+}
+
+// calcTopicsListSize returns size for the topics list.
+func calcTopicsListSize(width, height int) (int, int) {
+	return width/2 - 4, height - 4
+}
+
+// calcDetailSize returns size for the history detail view.
+func calcDetailSize(width, height int) (int, int) {
+	return width - 4, height - 4
+}
+
+// calcViewportHeight returns the viewport height, reserving two lines for headers.
+func calcViewportHeight(height int) int {
+	return height - 2
+}
+
 // handleWindowSize adjusts the layout when the terminal is resized.
 func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
 	m.ui.width = msg.Width
 	m.ui.height = msg.Height
-	m.connections.Manager.ConnectionsList.SetSize(msg.Width-4, msg.Height-6)
+	cw, ch := calcConnectionsSize(msg.Width, msg.Height)
+	m.connections.Manager.ConnectionsList.SetSize(cw, ch)
 	// textinput.View() renders the prompt and cursor in addition
 	// to the configured width. Reduce the width slightly so the
 	// surrounding box stays within the terminal boundaries.
-	m.topics.Input.Width = msg.Width - 7
-	m.message.Input().SetWidth(msg.Width - 4)
+	m.topics.Input.Width = calcTopicsInputWidth(msg.Width)
+	m.message.Input().SetWidth(calcMessageWidth(msg.Width))
 	m.message.Input().SetHeight(m.layout.message.height)
-	if m.layout.history.height == 0 {
-		m.layout.history.height = (msg.Height-1)/3 + 10
-	}
-	m.history.List().SetSize(msg.Width-4, m.layout.history.height)
-	if m.layout.trace.height == 0 {
-		m.layout.trace.height = msg.Height - 6
-	}
-	m.traces.ViewList().SetSize(msg.Width-4, m.layout.trace.height)
-	m.traces.List().SetSize(msg.Width-4, msg.Height-4)
-	m.topics.List().SetSize(msg.Width/2-4, msg.Height-4)
+	hw, hh := calcHistorySize(msg.Width, msg.Height, m.layout.history.height)
+	m.layout.history.height = hh
+	m.history.List().SetSize(hw, hh)
+	m.layout.trace.height = calcTraceHeight(msg.Height, m.layout.trace.height)
+	m.traces.ViewList().SetSize(calcMessageWidth(msg.Width), m.layout.trace.height)
+	tw, th := calcTraceListSize(msg.Width, msg.Height)
+	m.traces.List().SetSize(tw, th)
+	lw, lh := calcTopicsListSize(msg.Width, msg.Height)
+	m.topics.List().SetSize(lw, lh)
 	m.help.SetSize(msg.Width, msg.Height)
-	m.history.Detail().Width = msg.Width - 4
-	m.history.Detail().Height = msg.Height - 4
+	dw, dh := calcDetailSize(msg.Width, msg.Height)
+	m.history.Detail().Width = dw
+	m.history.Detail().Height = dh
 	m.ui.viewport.Width = msg.Width
 	// Reserve two lines for the info header at the top of the view.
-	m.ui.viewport.Height = msg.Height - 2
+	m.ui.viewport.Height = calcViewportHeight(msg.Height)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- add helper funcs for history, message, traces, topics sizing
- use helper funcs in handleWindowSize

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68934d0c909883248e165b793854cee9