### PR TITLE
docs: clarify test resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,12 @@ Scroll with `Ctrl+Up`/`Ctrl+Down` or `Ctrl+K`/`Ctrl+J`. In history,
 - New UI code should reuse this logic instead of writing custom forms.
 
 ## Test Info
-`ExampleSet_manual` in `keyring_util_test.go` requires a real keyring. It does not run during `go test ./...` and can be executed manually if needed.
+`ExampleSet_manual` in `keyring_util_test.go` requires a real keyring. It does not
+run during `go test ./...` and can be executed manually if needed:
+
+```bash
+go test -run ExampleSet_manual -tags manual
+```
 
 ## Maintenance
 Keep `README.md`, `TODO.md`, `AGENTS.md`, and `help/help.md` in sync when changes are made to the project or development workflow.

--- a/README.md
+++ b/README.md
@@ -144,9 +144,17 @@ This project is licensed under the terms of the MIT License. See [LICENSE](LICEN
 
 ## Testing
 
-Unit tests can be run with `go test ./...`. The example `ExampleSet_manual` in
-`keyring_util_test.go` interacts with the real system keyring and is excluded
-from automated runs. Execute it manually when a keyring is available.
+Unit tests run quickly offline with `go test ./...`; network calls are
+stubbed (the TLS client tests spin up a temporary loopback server).
+
+The example `ExampleSet_manual` in `keyring_util_test.go` touches the real
+system keyring and is skipped by default. Run it only when a keyring is
+available:
+
+```bash
+go test -run ExampleSet_manual -tags manual
+```
+
 Tests also cover configuration parsing and saved state persistence.
 
 Before sending a pull request run `go vet ./...` along with the tests to catch


### PR DESCRIPTION
## Summary
- Document that tests run offline with stubbed network usage
- Note the optional keyring example and show how to run it manually

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936ea5ca3c8324960b05d061fb81d4