### PR TITLE
Add mouse support to lists

### DIFF
--- a/history/history_component.go
+++ b/history/history_component.go
@@ -39,6 +39,14 @@ func (h *Component) Init() tea.Cmd { return nil }
 // Update updates the history list. The caller must ensure the list has focus.
 func (h *Component) Update(msg tea.Msg) tea.Cmd {
 	var cmd tea.Cmd
+	switch m := msg.(type) {
+	case tea.MouseMsg:
+		h.list, cmd = h.list.Update(m)
+		if m.Action == tea.MouseActionPress && m.Button == tea.MouseButtonLeft {
+			h.HandleSelection(h.list.Index(), m.Shift)
+		}
+		return cmd
+	}
 	h.list, cmd = h.list.Update(msg)
 	return cmd
 }

--- a/payloads/payloads_component.go
+++ b/payloads/payloads_component.go
@@ -64,6 +64,30 @@ func (p *Component) Update(msg tea.Msg) tea.Cmd {
 				}
 			}
 		}
+		p.list, cmd = p.list.Update(msg)
+		return tea.Batch(cmd, p.status.ListenStatus())
+	case tea.MouseMsg:
+		p.list, cmd = p.list.Update(msg)
+		idx := p.list.Index()
+		items := p.list.Items()
+		if msg.Action == tea.MouseActionPress && idx >= 0 && idx < len(items) {
+			switch msg.Button {
+			case tea.MouseButtonLeft:
+				pi := items[idx].(Item)
+				return tea.Batch(
+					cmd,
+					func() tea.Msg { return LoadMsg{Topic: pi.Topic, Payload: pi.Payload} },
+					p.m.SetClientMode(),
+					p.status.ListenStatus(),
+				)
+			case tea.MouseButtonRight:
+				p.items = append(p.items[:idx], p.items[idx+1:]...)
+				items = append(items[:idx], items[idx+1:]...)
+				p.list.SetItems(items)
+				return tea.Batch(cmd, p.status.ListenStatus())
+			}
+		}
+		return tea.Batch(cmd, p.status.ListenStatus())
 	}
 	p.list, cmd = p.list.Update(msg)
 	return tea.Batch(cmd, p.status.ListenStatus())

--- a/topics/component.go
+++ b/topics/component.go
@@ -95,6 +95,13 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 				c.TogglePublish(i)
 			}
 		}
+	case tea.MouseMsg:
+		if msg.Action == tea.MouseActionPress {
+			switch msg.Button {
+			case tea.MouseButtonLeft, tea.MouseButtonRight:
+				tcmd = c.HandleClick(msg, c.VP.YOffset)
+			}
+		}
 	}
 	c.list, cmd = c.list.Update(msg)
 	if c.panes.active == 0 {


### PR DESCRIPTION
## Summary
- handle MouseMsg in topics list to support mouse clicks
- enable mouse click actions in payloads list
- update history list to respond to mouse selection

## Testing
- `time go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936ea660188324af66bf6122523c88