### PR TITLE
handle empty topic action

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -14,6 +14,7 @@ import (
 // action should be "subscribe" or "unsubscribe".
 func (m *model) logTopicAction(topic, action string, err error) {
 	if len(action) == 0 {
+		m.history.Append(topic, "", "log", fmt.Sprintf("No action specified for topic: %s", topic))
 		return
 	}
 	act := strings.ToUpper(action[:1]) + action[1:]

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -143,16 +143,13 @@ func TestHandleTopicToggleUnsubscribeError(t *testing.T) {
 func TestLogTopicAction(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		m, _ := initialModel(nil)
-		func() {
-			defer func() {
-				if r := recover(); r != nil {
-					t.Fatalf("logTopicAction panicked: %v", r)
-				}
-			}()
-			m.logTopicAction("t1", "", nil)
-		}()
-		if len(m.history.Items()) != 0 {
-			t.Fatalf("expected no history items, got %d", len(m.history.Items()))
+		m.logTopicAction("t1", "", nil)
+		items := m.history.Items()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 history item, got %d", len(items))
+		}
+		if items[0].Kind != "log" || items[0].Payload != "No action specified for topic: t1" {
+			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- avoid slicing empty topic actions; log a default message instead
- add tests for empty, subscribe, and unsubscribe topic actions

## Testing
- `go vet ./...`
- `go test ./...` *(hangs, terminated after waiting)*
- `go test -run TestLogTopicAction -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68936fe617688324b508941fcd76df85