### PR TITLE
refactor: isolate run modes into helpers

### DIFF
--- a/run_test.go
+++ b/run_test.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+	connections "github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/help"
+	"github.com/marang/emqutiti/history"
+	"github.com/marang/emqutiti/importer"
 	"github.com/marang/emqutiti/traces"
 )
 
@@ -29,6 +34,32 @@ func (s *stubTraceStore) HasData(string, string) (bool, error)                  
 func (s *stubTraceStore) ClearData(string, string) error                          { return nil }
 func (s *stubTraceStore) LoadCounts(string, string, []string) (map[string]int, error) {
 	return nil, nil
+}
+
+type stubProgram struct{ run func() (tea.Model, error) }
+
+func (s stubProgram) Run() (tea.Model, error) { return s.run() }
+
+type stubMQTTClient struct{ disconnected bool }
+
+func (s *stubMQTTClient) Publish(topic string, qos byte, retained bool, payload interface{}) error {
+	return nil
+}
+
+func (s *stubMQTTClient) Disconnect() { s.disconnected = true }
+
+type stubHistoryStore struct{ closed bool }
+
+func (s *stubHistoryStore) Append(history.Message) {}
+func (s *stubHistoryStore) Search(bool, []string, time.Time, time.Time, string) []history.Message {
+	return nil
+}
+func (s *stubHistoryStore) Delete(string) error  { return nil }
+func (s *stubHistoryStore) Archive(string) error { return nil }
+func (s *stubHistoryStore) Count(bool) int       { return 0 }
+func (s *stubHistoryStore) Close() error {
+	s.closed = true
+	return nil
 }
 
 func TestRunTrace(t *testing.T) {
@@ -147,4 +178,64 @@ func TestMainDispatchUI(t *testing.T) {
 		t.Fatalf("runUI not called")
 	}
 	runImportFn, runTraceFn, runUIFn = origImport, origTrace, origUI
+}
+
+func TestRunImport(t *testing.T) {
+	origLoad, origClient, origImp, origProg := loadProfileFn, newMQTTClientFn, newImporterFn, newProgramFn
+	defer func() {
+		loadProfileFn, newMQTTClientFn, newImporterFn, newProgramFn = origLoad, origClient, origImp, origProg
+	}()
+	os.Setenv("EMQUTITI_DEFAULT_PASSWORD", "pw")
+	defer os.Unsetenv("EMQUTITI_DEFAULT_PASSWORD")
+
+	loadProfileFn = func(name, _ string) (*connections.Profile, error) {
+		if name != "pr" {
+			t.Fatalf("unexpected profile %s", name)
+		}
+		return &connections.Profile{}, nil
+	}
+	client := &stubMQTTClient{}
+	newMQTTClientFn = func(p connections.Profile, fn statusFunc) (mqttClient, error) {
+		if p.Password != "pw" {
+			t.Fatalf("expected password override, got %s", p.Password)
+		}
+		return client, nil
+	}
+	newImporterFn = func(cl importer.Publisher, path string) *importer.Model {
+		if cl != client || path != "file" {
+			t.Fatalf("unexpected importer args")
+		}
+		return nil
+	}
+	newProgramFn = func(m tea.Model, opts ...tea.ProgramOption) program {
+		return stubProgram{run: func() (tea.Model, error) { return nil, nil }}
+	}
+	if err := runImport("file", "pr"); err != nil {
+		t.Fatalf("runImport error: %v", err)
+	}
+	if !client.disconnected {
+		t.Fatalf("client not disconnected")
+	}
+}
+
+func TestRunUI(t *testing.T) {
+	origInit, origProg := initialModelFn, newProgramFn
+	defer func() { initialModelFn, newProgramFn = origInit, origProg }()
+
+	initialModelFn = func(*connections.Connections) (*model, error) {
+		return &model{help: &help.Component{}}, nil
+	}
+	st := &stubHistoryStore{}
+	newProgramFn = func(m tea.Model, opts ...tea.ProgramOption) program {
+		return stubProgram{run: func() (tea.Model, error) {
+			hc := history.NewComponent(nil, st)
+			return &model{history: hc}, nil
+		}}
+	}
+	if err := runUI(); err != nil {
+		t.Fatalf("runUI error: %v", err)
+	}
+	if !st.closed {
+		t.Fatalf("store not closed")
+	}
 }


### PR DESCRIPTION
## Summary
- break out tracing, import, and UI startup helpers for clearer dispatch
- add injection points for easier testing
- cover import and UI helpers with unit tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936fe6b90483249e0dd648db947593