### PR TITLE
feat: add context-based timeouts for MQTT operations

### DIFF
--- a/connections/profile.go
+++ b/connections/profile.go
@@ -9,24 +9,27 @@ import (
 
 // Profile defines a broker connection.
 type Profile struct {
-	Name                string `toml:"name" env:"name"`
-	Schema              string `toml:"schema" env:"schema"`
-	Host                string `toml:"host" env:"host"`
-	Port                int    `toml:"port" env:"port"`
-	ClientID            string `toml:"client_id" env:"client_id"`
-	Username            string `toml:"username" env:"username"`
-	Password            string `toml:"password" env:"password"`
-	FromEnv             bool   `toml:"from_env"`
-	SSL                 bool   `toml:"ssl_tls" env:"ssl_tls"`
-	SkipTLSVerify       bool   `toml:"skip_tls_verify" env:"skip_tls_verify"`
-	MQTTVersion         string `toml:"mqtt_version" env:"mqtt_version"`
-	ConnectTimeout      int    `toml:"connect_timeout" env:"connect_timeout"`
-	KeepAlive           int    `toml:"keep_alive" env:"keep_alive"`
-	QoS                 int    `toml:"qos" env:"qos"`
-	AutoReconnect       bool   `toml:"auto_reconnect" env:"auto_reconnect"`
-	ReconnectPeriod     int    `toml:"reconnect_period" env:"reconnect_period"`
-	PublishTimeout      int    `toml:"publish_timeout" env:"publish_timeout"`
-	SubscribeTimeout    int    `toml:"subscribe_timeout" env:"subscribe_timeout"`
+	Name            string `toml:"name" env:"name"`
+	Schema          string `toml:"schema" env:"schema"`
+	Host            string `toml:"host" env:"host"`
+	Port            int    `toml:"port" env:"port"`
+	ClientID        string `toml:"client_id" env:"client_id"`
+	Username        string `toml:"username" env:"username"`
+	Password        string `toml:"password" env:"password"`
+	FromEnv         bool   `toml:"from_env"`
+	SSL             bool   `toml:"ssl_tls" env:"ssl_tls"`
+	SkipTLSVerify   bool   `toml:"skip_tls_verify" env:"skip_tls_verify"`
+	MQTTVersion     string `toml:"mqtt_version" env:"mqtt_version"`
+	ConnectTimeout  int    `toml:"connect_timeout" env:"connect_timeout"`
+	KeepAlive       int    `toml:"keep_alive" env:"keep_alive"`
+	QoS             int    `toml:"qos" env:"qos"`
+	AutoReconnect   bool   `toml:"auto_reconnect" env:"auto_reconnect"`
+	ReconnectPeriod int    `toml:"reconnect_period" env:"reconnect_period"`
+	// PublishTimeout is the time in seconds to wait for a publish token.
+	PublishTimeout int `toml:"publish_timeout" env:"publish_timeout"`
+	// SubscribeTimeout is the time in seconds to wait for a subscribe token.
+	SubscribeTimeout int `toml:"subscribe_timeout" env:"subscribe_timeout"`
+	// UnsubscribeTimeout is the time in seconds to wait for an unsubscribe token.
 	UnsubscribeTimeout  int    `toml:"unsubscribe_timeout" env:"unsubscribe_timeout"`
 	CleanStart          bool   `toml:"clean_start" env:"clean_start"`
 	SessionExpiry       int    `toml:"session_expiry_interval" env:"session_expiry_interval"`

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -1,6 +1,7 @@
 package emqutiti
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	connections "github.com/marang/emqutiti/connections"
@@ -18,14 +19,40 @@ type MQTTMessage struct {
 }
 
 type MQTTClient struct {
-	Client             mqtt.Client
-  // MessageChan receives published messages. It is closed when
+	Client mqtt.Client
+	// MessageChan receives published messages. It is closed when
 	// Disconnect is called, so consumers must handle channel
 	// closure.
 	MessageChan        chan MQTTMessage
 	publishTimeout     time.Duration
 	subscribeTimeout   time.Duration
 	unsubscribeTimeout time.Duration
+}
+
+// waitToken blocks until the MQTT token completes or the timeout expires.
+// It returns any error from the token or a timeout error.
+func waitToken(token mqtt.Token, timeout time.Duration, action string) error {
+	if timeout <= 0 {
+		timeout = defaultTokenTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		token.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if err := token.Error(); err != nil {
+			return fmt.Errorf("%s failed: %w", action, err)
+		}
+		return nil
+	case <-ctx.Done():
+		return fmt.Errorf("%s timeout after %v", action, timeout)
+	}
 }
 
 // NewMQTTClient creates and configures a new MQTT client based on the profile
@@ -111,17 +138,7 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 // broker.
 func (m *MQTTClient) Publish(topic string, qos byte, retained bool, payload interface{}) error {
 	token := m.Client.Publish(topic, qos, retained, payload)
-	timeout := m.publishTimeout
-	if timeout <= 0 {
-		timeout = defaultTokenTimeout
-	}
-	if !token.WaitTimeout(timeout) {
-		return fmt.Errorf("publish timeout after %v", timeout)
-	}
-	if token.Error() != nil {
-		return fmt.Errorf("publish failed: %w", token.Error())
-	}
-	return nil
+	return waitToken(token, m.publishTimeout, "publish")
 }
 
 // Subscribe registers callback for messages on topic at the specified QoS.
@@ -129,34 +146,14 @@ func (m *MQTTClient) Publish(topic string, qos byte, retained bool, payload inte
 // returns an error if the request fails.
 func (m *MQTTClient) Subscribe(topic string, qos byte, callback mqtt.MessageHandler) error {
 	token := m.Client.Subscribe(topic, qos, callback)
-	timeout := m.subscribeTimeout
-	if timeout <= 0 {
-		timeout = defaultTokenTimeout
-	}
-	if !token.WaitTimeout(timeout) {
-		return fmt.Errorf("subscribe timeout after %v", timeout)
-	}
-	if token.Error() != nil {
-		return fmt.Errorf("subscribe failed: %w", token.Error())
-	}
-	return nil
+	return waitToken(token, m.subscribeTimeout, "subscribe")
 }
 
 // Unsubscribe removes the subscription for the topic. It waits for
 // completion and returns an error if the unsubscribe request fails.
 func (m *MQTTClient) Unsubscribe(topic string) error {
 	token := m.Client.Unsubscribe(topic)
-	timeout := m.unsubscribeTimeout
-	if timeout <= 0 {
-		timeout = defaultTokenTimeout
-	}
-	if !token.WaitTimeout(timeout) {
-		return fmt.Errorf("unsubscribe timeout after %v", timeout)
-	}
-	if token.Error() != nil {
-		return fmt.Errorf("unsubscribe failed: %w", token.Error())
-	}
-	return nil
+	return waitToken(token, m.unsubscribeTimeout, "unsubscribe")
 }
 
 // Disconnect cleanly closes the connection to the broker and closes


### PR DESCRIPTION
## Summary
- use context-based token waiting in Publish, Subscribe, and Unsubscribe
- document timeout fields on connection profiles

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936fe7713083249de44d04abeb68be