### PR TITLE
use key constants across handlers

### DIFF
--- a/client_keys_topics.go
+++ b/client_keys_topics.go
@@ -33,7 +33,7 @@ func (m *model) handleRightKey() tea.Cmd {
 // handleTopicScroll handles scroll keys when topics are focused.
 func (m *model) handleTopicScroll(key string) tea.Cmd {
 	delta := -1
-	if key == "down" || key == "j" {
+	if key == constants.KeyDown || key == constants.KeyJ {
 		delta = 1
 	}
 	m.topics.Scroll(delta)

--- a/connections/connections.go
+++ b/connections/connections.go
@@ -6,6 +6,8 @@ import (
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
 )
 
 // Connections manages the state and logic for handling broker profiles.
@@ -47,7 +49,7 @@ func (m Connections) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		if m.Focused && msg.String() == "a" {
+		if m.Focused && msg.String() == constants.KeyA {
 			m.TextInput.Focus()
 		}
 	}

--- a/constants/keys.go
+++ b/constants/keys.go
@@ -11,6 +11,8 @@ const (
 	KeyDown          = "down"
 	KeyLeft          = "left"
 	KeyRight         = "right"
+	KeyPgUp          = "pgup"
+	KeyPgDown        = "pgdown"
 	KeyK             = "k"
 	KeyJ             = "j"
 	KeyH             = "h"

--- a/inputs.go
+++ b/inputs.go
@@ -4,6 +4,7 @@ import (
 	list "github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/marang/emqutiti/constants"
 	"github.com/marang/emqutiti/history"
 )
 
@@ -34,7 +35,7 @@ func (m *model) updateViewport(msg tea.Msg) tea.Cmd {
 		switch mt := msg.(type) {
 		case tea.KeyMsg:
 			s := mt.String()
-			if s == "up" || s == "down" || s == "pgup" || s == "pgdown" || s == "k" || s == "j" {
+			if s == constants.KeyUp || s == constants.KeyDown || s == constants.KeyPgUp || s == constants.KeyPgDown || s == constants.KeyK || s == constants.KeyJ {
 				skipVP = true
 			}
 		case tea.MouseMsg:

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -91,7 +91,8 @@ func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
 
 // handleKeyNav processes global navigation key presses.
 func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
-	switch msg.String() {
+	key := msg.String()
+	switch key {
 	case constants.KeyCtrlUp, constants.KeyCtrlK:
 		m.ui.viewport.ScrollUp(1)
 		return nil, true
@@ -145,7 +146,7 @@ func (m *model) handleKeyNav(msg tea.KeyMsg) (tea.Cmd, bool) {
 	}
 
 	if m.CurrentMode() != constants.ModeHistoryFilter &&
-		(msg.String() == constants.KeyEnter || msg.String() == constants.KeySpaceBar || msg.String() == constants.KeySpace) &&
+		(key == constants.KeyEnter || key == constants.KeySpaceBar || key == constants.KeySpace) &&
 		m.help.Focused() {
 		return m.SetMode(constants.ModeHelp), true
 	}


### PR DESCRIPTION
## Summary
- add pgup/pgdown to shared key constants
- replace hardcoded key strings in handlers
- refactor global nav to reuse key string

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68936fea5e5483248a0b08549777c0a0