### PR TITLE
Ignore empty topic action logs

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -14,7 +14,6 @@ import (
 // action should be "subscribe" or "unsubscribe".
 func (m *model) logTopicAction(topic, action string, err error) {
 	if len(action) == 0 {
-		m.history.Append(topic, "", "log", fmt.Sprintf("No action specified for topic: %s", topic))
 		return
 	}
 	act := strings.ToUpper(action[:1]) + action[1:]

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -144,12 +144,8 @@ func TestLogTopicAction(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		m, _ := initialModel(nil)
 		m.logTopicAction("t1", "", nil)
-		items := m.history.Items()
-		if len(items) != 1 {
-			t.Fatalf("expected 1 history item, got %d", len(items))
-		}
-		if items[0].Kind != "log" || items[0].Payload != "No action specified for topic: t1" {
-			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
+		if len(m.history.Items()) != 0 {
+			t.Fatalf("expected no history items, got %d", len(m.history.Items()))
 		}
 	})
 


### PR DESCRIPTION
## Summary
- avoid logging history entries when no topic action is specified
- adjust tests to expect zero log entries for empty actions

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68937526bcac832492cb3d617d0a17a5