### PR TITLE
log empty topic actions

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -12,8 +12,10 @@ import (
 
 // logTopicAction appends a log entry for a topic action.
 // action should be "subscribe" or "unsubscribe".
+// An empty action logs a no-op message.
 func (m *model) logTopicAction(topic, action string, err error) {
 	if len(action) == 0 {
+		m.history.Append(topic, "", "log", fmt.Sprintf("No action specified for topic: %s", topic))
 		return
 	}
 	act := strings.ToUpper(action[:1]) + action[1:]

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -144,8 +144,12 @@ func TestLogTopicAction(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		m, _ := initialModel(nil)
 		m.logTopicAction("t1", "", nil)
-		if len(m.history.Items()) != 0 {
-			t.Fatalf("expected no history items, got %d", len(m.history.Items()))
+		items := m.history.Items()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 history item, got %d", len(items))
+		}
+		if items[0].Kind != "log" || items[0].Payload != "No action specified for topic: t1" {
+			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- log message when topic action is missing
- update tests for empty action

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893794f888083249f354e016cc926d2