### PR TITLE
Use cyan help icon with dark gray focus

### DIFF
--- a/ui/styles.go
+++ b/ui/styles.go
@@ -21,8 +21,8 @@ var (
 	ErrorStyle      = lipgloss.NewStyle().Foreground(ColWarn).PaddingLeft(1)
 	InfoSubtleStyle = lipgloss.NewStyle().Foreground(ColGray).PaddingLeft(1)
 
-	HelpStyle   = lipgloss.NewStyle().Foreground(ColGreen)
-	HelpFocused = HelpStyle.Background(ColPink)
+	HelpStyle   = lipgloss.NewStyle().Foreground(ColCyan)
+	HelpFocused = HelpStyle.Foreground(ColDarkGray).Background(ColPink)
 	HelpHeader  = lipgloss.NewStyle().Foreground(ColCyan).Bold(true).Underline(true)
 	HelpKey     = lipgloss.NewStyle().Foreground(ColGreen).Width(20)
 )


### PR DESCRIPTION
## Summary
- make the help '?' use cyan when unfocused
- switch to dark gray text when highlighted with a pink background

## Testing
- `go vet ./...`
- `go test ./...` *(fails: TestLogTopicActionEmpty: expected 1 history item, got 0)*

------
https://chatgpt.com/codex/tasks/task_e_689379aaeffc83249e29a8b911b83f5f