### PR TITLE
refine CLI flag help

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If a profile is marked as default, the app connects to it automatically on start
 
 ### Importing from CSV or XLS
 
-Launch `emqutiti --import data.csv -p local` to map columns to JSON and publish them. The wizard supports dry runs and will remember settings in future versions.
+Launch `emqutiti -i data.csv -p local` (or `--import data.csv --profile local`) to map columns to JSON and publish them. The wizard supports dry runs and will remember settings in future versions.
 
 Press `Ctrl+R` in the UI to manage recorded traces.
 
@@ -43,16 +43,22 @@ Press `Ctrl+R` in the UI to manage recorded traces.
 Run traces without the UI:
 
 ```
-emqutiti --trace myrun --topics "sensors/#" -p local
+emqutiti --trace run1 --topics "sensors/#" -p local
 ```
 
 Flags:
 
-- `--trace` trace name
-- `--topics` topic filter
-- `-p`, `--profile` connection profile
-- `--start` RFC3339 start time
-- `--end` RFC3339 end time
+General
+
+- `-i, --import FILE` Launch import wizard with optional file path (e.g., `-i data.csv`)
+- `-p, --profile NAME` Connection profile name to use (e.g., `-p local`)
+
+Trace
+
+- `--trace KEY` Trace key name to store messages (e.g., `--trace run1`)
+- `--topics LIST` Comma-separated topics to trace (e.g., `--topics "sensors/#"`)
+- `--start TIME` Optional RFC3339 start time (e.g., `--start "2025-08-05T11:47:00Z"`)
+- `--end TIME` Optional RFC3339 end time (e.g., `--end "2025-08-05T11:49:00Z"`)
 
 Times must be RFC3339 formatted.
 

--- a/help/help.md
+++ b/help/help.md
@@ -75,3 +75,17 @@
 ## Tips
 
 - Set `EMQUTITI_DEFAULT_PASSWORD` to override profile passwords when not loading from env.
+
+## CLI Flags
+
+**General**
+
+- `-i, --import FILE` Launch import wizard with optional file path (e.g., `-i data.csv`)
+- `-p, --profile NAME` Connection profile name to use (e.g., `-p local`)
+
+**Trace**
+
+- `--trace KEY` Trace key name to store messages (e.g., `--trace run1`)
+- `--topics LIST` Comma-separated topics to trace (e.g., `--topics "sensors/#"`)
+- `--start TIME` Optional RFC3339 start time (e.g., `--start "2025-08-05T11:47:00Z"`)
+- `--end TIME` Optional RFC3339 end time (e.g., `--end "2025-08-05T11:49:00Z"`)

--- a/help/help_test.go
+++ b/help/help_test.go
@@ -49,6 +49,7 @@ func TestRenderHelpGroupsSections(t *testing.T) {
 		"History",
 		"Traces",
 		"Tips",
+		"CLI Flags",
 	}
 	for _, e := range expected {
 		if !strings.Contains(plain, e) {

--- a/run.go
+++ b/run.go
@@ -61,12 +61,26 @@ type mqttClient interface {
 func registerFlags(fs *flag.FlagSet) {
 	fs.StringVar(&importFile, "import", "", "Launch import wizard with optional file path")
 	fs.StringVar(&importFile, "i", "", "(shorthand)")
-	fs.StringVar(&profileName, "profile", "", "Connection profile to use")
+	fs.StringVar(&profileName, "profile", "", "Connection profile name to use")
 	fs.StringVar(&profileName, "p", "", "(shorthand)")
-	fs.StringVar(&traceKey, "trace", "", "Trace key to store messages under")
+	fs.StringVar(&traceKey, "trace", "", "Trace key name to store messages")
 	fs.StringVar(&traceTopics, "topics", "", "Comma-separated topics to trace")
 	fs.StringVar(&traceStart, "start", "", "Optional RFC3339 trace start time")
 	fs.StringVar(&traceEnd, "end", "", "Optional RFC3339 trace end time")
+
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintf(w, "Usage: %s [flags]\n\n", os.Args[0])
+		fmt.Fprintln(w, "General:")
+		fmt.Fprintln(w, "  -i, --import FILE     Launch import wizard with optional file path (e.g., -i data.csv)")
+		fmt.Fprintln(w, "  -p, --profile NAME    Connection profile name to use (e.g., -p local)")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "Trace:")
+		fmt.Fprintln(w, "      --trace KEY       Trace key name to store messages (e.g., --trace run1)")
+		fmt.Fprintln(w, "      --topics LIST     Comma-separated topics to trace (e.g., --topics \"sensors/#\")")
+		fmt.Fprintln(w, "      --start TIME      Optional RFC3339 trace start time (e.g., --start \"2025-08-05T11:47:00Z\")")
+		fmt.Fprintln(w, "      --end TIME        Optional RFC3339 trace end time (e.g., --end \"2025-08-05T11:49:00Z\")")
+	}
 }
 
 // init registers CLI flags for tracing and import modes.


### PR DESCRIPTION
## Summary
- group CLI flag help under general and trace sections with examples and short/long forms
- document CLI flags in README and in-app help, explaining profile names and trace keys
- add unit test coverage for new CLI flag help section

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689380f1adcc8324a43ddaae50456d13