### PR TITLE
Clamp connection list width in edit view

### DIFF
--- a/connections/component.go
+++ b/connections/component.go
@@ -196,6 +196,9 @@ func (c *Component) Update(msg tea.Msg) tea.Cmd {
 func (c *Component) View() string {
 	c.api.ResetElemPos()
 	c.api.SetElemPos(constants.IDConnList, 1)
+	cw := c.nav.Width() - 4
+	ch := c.nav.Height() - 6
+	c.api.Manager().ConnectionsList.SetSize(cw, ch)
 	listView := c.api.Manager().ConnectionsList.View()
 	help := ui.InfoStyle.Render("[enter] connect/open client  [x] disconnect  [a]dd [e]dit [del] delete  Ctrl+O default  Ctrl+R traces")
 	content := lipgloss.JoinVertical(lipgloss.Left, listView, help)

--- a/view_form.go
+++ b/view_form.go
@@ -14,6 +14,8 @@ func (m *model) viewForm() string {
 	if m.connections.Form == nil {
 		return ""
 	}
+	cw, ch := calcConnectionsSize(m.ui.width/2, m.ui.height)
+	m.connections.Manager.ConnectionsList.SetSize(cw, ch)
 	listView := ui.LegendBox(m.connections.Manager.ConnectionsList.View(), "Brokers", m.ui.width/2-2, 0, ui.ColBlue, false, -1)
 	formLabel := "Add Broker"
 	if m.connections.Form.Index >= 0 {


### PR DESCRIPTION
## Summary
- ensure connections list resizes to available width
- keep long broker errors inside the list box

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689381e34204832485e322e892c5227f