### PR TITLE
Open help view when clicking icon

### DIFF
--- a/help_click_test.go
+++ b/help_click_test.go
@@ -1,0 +1,21 @@
+package emqutiti
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
+
+// Test that clicking the help icon opens the help view.
+func TestHelpIconClick(t *testing.T) {
+	m, _ := initialModel(nil)
+	m.ui.width = 80
+	m.ui.elemPos[idHelp] = 0
+	msg := tea.MouseMsg{X: 80, Y: 1, Type: tea.MouseLeft, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress}
+	m.handleClientMouse(msg)
+	if m.CurrentMode() != constants.ModeHelp {
+		t.Fatalf("expected ModeHelp, got %v", m.CurrentMode())
+	}
+}

--- a/mouse.go
+++ b/mouse.go
@@ -1,6 +1,12 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/marang/emqutiti/constants"
+	"github.com/marang/emqutiti/ui"
+)
 
 // isHistoryFocused reports if the history list has focus.
 func (m *model) isHistoryFocused() bool {
@@ -37,6 +43,10 @@ func (m *model) handleMouseLeft(msg tea.MouseMsg) tea.Cmd {
 	cmd := m.focusFromMouse(msg.Y)
 	if m.isHistoryFocused() && !m.history.ShowArchived() {
 		m.history.HandleClick(msg, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
+	}
+	helpWidth := lipgloss.Width(ui.HelpStyle.Render("?"))
+	if msg.Y == 1 && msg.X >= m.ui.width-helpWidth+1 {
+		m.SetMode(constants.ModeHelp)
 	}
 	return cmd
 }


### PR DESCRIPTION
## Summary
- open help view when the `?` icon is clicked
- add regression test for clickable help

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68938698f2308324a2b45c041ae13910