### PR TITLE
Open help view when clicking icon

### DIFF
--- a/help_click_test.go
+++ b/help_click_test.go
@@ -1,0 +1,20 @@
+package emqutiti
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/marang/emqutiti/constants"
+)
+
+// Test that clicking the help icon opens the help view.
+func TestHelpIconClick(t *testing.T) {
+	m, _ := initialModel(nil)
+	m.ui.width = 80
+	msg := tea.MouseMsg{X: 79, Y: 0, Type: tea.MouseLeft, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress}
+	m.Update(msg)
+	if m.CurrentMode() != constants.ModeHelp {
+		t.Fatalf("expected ModeHelp, got %v", m.CurrentMode())
+	}
+}

--- a/mouse.go
+++ b/mouse.go
@@ -1,6 +1,12 @@
 package emqutiti
 
-import tea "github.com/charmbracelet/bubbletea"
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/marang/emqutiti/constants"
+	"github.com/marang/emqutiti/ui"
+)
 
 // isHistoryFocused reports if the history list has focus.
 func (m *model) isHistoryFocused() bool {
@@ -32,13 +38,33 @@ func (m *model) handleMouseScroll(msg tea.MouseMsg) (tea.Cmd, bool) {
 	return nil, false
 }
 
+// handleHelpClick switches to help mode when the icon is clicked.
+func (m *model) handleHelpClick(msg tea.MouseMsg) (tea.Cmd, bool) {
+	helpWidth := lipgloss.Width(ui.HelpStyle.Render("?"))
+	if msg.Y == 0 && msg.X >= m.ui.width-helpWidth {
+		return m.SetMode(constants.ModeHelp), true
+	}
+	return nil, false
+}
+
 // handleMouseLeft manages left-click focus and selection.
 func (m *model) handleMouseLeft(msg tea.MouseMsg) tea.Cmd {
+	if cmd, handled := m.handleHelpClick(msg); handled {
+		return cmd
+	}
 	cmd := m.focusFromMouse(msg.Y)
 	if m.isHistoryFocused() && !m.history.ShowArchived() {
 		m.history.HandleClick(msg, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
 	}
 	return cmd
+}
+
+// handleMouse processes mouse events common to all modes.
+func (m *model) handleMouse(msg tea.MouseMsg) tea.Cmd {
+	if cmd, handled := m.handleHelpClick(msg); handled {
+		return cmd
+	}
+	return nil
 }
 
 // handleClientMouse processes mouse events in client mode.

--- a/update.go
+++ b/update.go
@@ -18,6 +18,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.topics.SetTopic(msg.Topic)
 		m.message.SetPayload(msg.Payload)
 		return m, nil
+	case tea.MouseMsg:
+		if cmd := m.handleMouse(msg); cmd != nil {
+			return m, cmd
+		}
 	case tea.KeyMsg:
 		if cmd, handled := m.handleKeyNav(msg); handled {
 			return m, cmd


### PR DESCRIPTION
## Summary
- handle top-right help icon click across views using zero-based mouse coordinates
- route mouse events through Update and cover with regression test

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68938698f2308324a2b45c041ae13910