### PR TITLE
ui: list select options when focused

### DIFF
--- a/connections/form.go
+++ b/connections/form.go
@@ -180,6 +180,11 @@ func (f Form) View() string {
 			label = ui.FocusedStyle.Render(label)
 		}
 		s += fmt.Sprintf("%s: %s\n", label, in.View())
+		if sf, ok := in.(*ui.SelectField); ok && f.IsFocused(i) {
+			if opts := sf.OptionsView(); opts != "" {
+				s += opts + "\n"
+			}
+		}
 	}
 	idxFromEnv := fieldIndex["FromEnv"]
 	idxName := fieldIndex["Name"]

--- a/traces/traceform.go
+++ b/traces/traceform.go
@@ -69,6 +69,11 @@ func (f traceForm) View() string {
 			label = ui.FocusedStyle.Render(label)
 		}
 		b.WriteString(label + ": " + fld.View() + "\n")
+		if sf, ok := fld.(*ui.SelectField); ok && f.IsFocused(i) {
+			if opts := sf.OptionsView(); opts != "" {
+				b.WriteString(opts + "\n")
+			}
+		}
 	}
 	if f.errMsg != "" {
 		b.WriteString("\n" + ui.ErrorStyle.Render(f.errMsg))

--- a/ui/form_select.go
+++ b/ui/form_select.go
@@ -1,7 +1,10 @@
 package ui
 
 import (
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/marang/emqutiti/constants"
 )
@@ -73,3 +76,20 @@ func (s *SelectField) View() string {
 }
 
 func (s *SelectField) Value() string { return s.options[s.Index] }
+
+// OptionsView renders the available options when the field is focused.
+// The current selection is highlighted.
+func (s *SelectField) OptionsView() string {
+	if !s.focused || len(s.options) == 0 {
+		return ""
+	}
+	items := make([]string, len(s.options))
+	for i, opt := range s.options {
+		st := lipgloss.NewStyle().Foreground(ColBlue)
+		if i == s.Index {
+			st = st.Foreground(ColPink)
+		}
+		items[i] = st.Render(opt)
+	}
+	return strings.Join(items, "\n")
+}


### PR DESCRIPTION
## Summary
- Add `OptionsView` to `SelectField` to list all options and highlight the current selection.
- Render option lists for focused select fields in connection and trace forms.

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893905da0b483249adee23ebf7b050e