### PR TITLE
Add tests for SelectField and CheckField behavior

### DIFF
--- a/ui/form_check_test.go
+++ b/ui/form_check_test.go
@@ -1,0 +1,38 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestCheckFieldToggleKeyboard(t *testing.T) {
+	cf := NewCheckField(false)
+	cf.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if !cf.Bool() {
+		t.Fatalf("expected true after space")
+	}
+	cf.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if cf.Bool() {
+		t.Fatalf("expected false after second space")
+	}
+}
+
+func TestCheckFieldToggleMouse(t *testing.T) {
+	cf := NewCheckField(false)
+	cf.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+	if !cf.Bool() {
+		t.Fatalf("expected true after click")
+	}
+}
+
+func TestCheckFieldReadOnly(t *testing.T) {
+	cf := NewCheckField(false)
+	cf.SetReadOnly(true)
+
+	cf.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	cf.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft})
+	if cf.Bool() {
+		t.Fatalf("read-only field toggled")
+	}
+}

--- a/ui/form_select_test.go
+++ b/ui/form_select_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestSelectFieldCyclesOptions(t *testing.T) {
+	sf := NewSelectField("one", []string{"one", "two", "three"})
+	sf.Focus()
+
+	// cycle backward from first wraps to last
+	sf.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	if got, want := sf.Index, 2; got != want {
+		t.Fatalf("index=%d want=%d", got, want)
+	}
+
+	// cycle forward with right wraps around
+	sf.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got, want := sf.Index, 0; got != want {
+		t.Fatalf("index=%d want=%d", got, want)
+	}
+
+	// space advances
+	sf.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+	if got, want := sf.Index, 1; got != want {
+		t.Fatalf("index=%d want=%d", got, want)
+	}
+
+	// forward again
+	sf.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got, want := sf.Index, 2; got != want {
+		t.Fatalf("index=%d want=%d", got, want)
+	}
+}
+
+func TestSelectFieldOptionsView(t *testing.T) {
+	sf := NewSelectField("two", []string{"one", "two", "three"})
+	if opts := sf.OptionsView(); opts != "" {
+		t.Fatalf("expected empty options when unfocused, got %q", opts)
+	}
+
+	sf.Focus()
+	expected := strings.Join([]string{
+		lipgloss.NewStyle().Foreground(ColBlue).Render("one"),
+		lipgloss.NewStyle().Foreground(ColPink).Render("two"),
+		lipgloss.NewStyle().Foreground(ColBlue).Render("three"),
+	}, "\n")
+	if opts := sf.OptionsView(); opts != expected {
+		t.Fatalf("options view=%q want=%q", opts, expected)
+	}
+}
+
+func TestSelectFieldReadOnly(t *testing.T) {
+	sf := NewSelectField("one", []string{"one", "two"})
+	sf.SetReadOnly(true)
+	sf.Focus()
+
+	if opts := sf.OptionsView(); opts != "" {
+		t.Fatalf("read-only field should not focus")
+	}
+
+	sf.Update(tea.KeyMsg{Type: tea.KeyRight})
+	if got, want := sf.Value(), "one"; got != want {
+		t.Fatalf("value=%s want=%s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- add SelectField tests for cycling, options rendering, and read-only handling
- add CheckField tests for keyboard/mouse toggling and read-only

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689397682c588324b3ad4976d9ebcb05