### PR TITLE
Expose read-only state on form fields

### DIFF
--- a/connections/form.go
+++ b/connections/form.go
@@ -123,9 +123,7 @@ func NewForm(p Profile, idx int) Form {
 			if i == idxName || i == idxFromEnv {
 				continue
 			}
-			if ro, ok := fld.(interface{ SetReadOnly(bool) }); ok {
-				ro.SetReadOnly(true)
-			}
+			fld.SetReadOnly(true)
 		}
 	}
 	cf := Form{Form: ui.Form{Fields: fields, Focus: 0}, Index: idx, fromEnv: p.FromEnv}

--- a/ui/form.go
+++ b/ui/form.go
@@ -13,6 +13,8 @@ type Field interface {
 	Update(msg tea.Msg) tea.Cmd
 	View() string
 	Value() string
+	ReadOnly() bool
+	SetReadOnly(bool)
 }
 
 // KeyConsumer reports whether a field wants to handle a key itself instead of
@@ -64,14 +66,5 @@ func (f *Form) IsFocused(idx int) bool {
 	if idx != f.Focus || idx < 0 || idx >= len(f.Fields) {
 		return false
 	}
-	switch fld := f.Fields[idx].(type) {
-	case *TextField:
-		return fld.Model.Focused() && !fld.readOnly
-	case *SelectField:
-		return fld.focused && !fld.readOnly
-	case *CheckField:
-		return fld.focused && !fld.readOnly
-	default:
-		return true
-	}
+	return !f.Fields[idx].ReadOnly()
 }

--- a/ui/form_check.go
+++ b/ui/form_check.go
@@ -16,9 +16,18 @@ type CheckField struct {
 // NewCheckField creates a CheckField with initial value.
 func NewCheckField(val bool) *CheckField { return &CheckField{value: val} }
 
-func (c *CheckField) Focus()              { c.focused = true }
-func (c *CheckField) Blur()               { c.focused = false }
-func (c *CheckField) SetReadOnly(ro bool) { c.readOnly = ro }
+func (c *CheckField) Focus() {
+	if !c.readOnly {
+		c.focused = true
+	}
+}
+func (c *CheckField) Blur() { c.focused = false }
+func (c *CheckField) SetReadOnly(ro bool) {
+	c.readOnly = ro
+	if ro {
+		c.Blur()
+	}
+}
 
 // ReadOnly reports whether the field is read only.
 func (c *CheckField) ReadOnly() bool { return c.readOnly }

--- a/ui/form_text.go
+++ b/ui/form_text.go
@@ -48,8 +48,11 @@ func (t *TextField) Update(msg tea.Msg) tea.Cmd {
 
 // Value returns the text content of the field.
 func (t *TextField) Value() string { return t.Model.Value() }
-
-func (t *TextField) Focus()       { t.Model.Focus() }
+func (t *TextField) Focus() {
+	if !t.readOnly {
+		t.Model.Focus()
+	}
+}
 func (t *TextField) Blur()        { t.Model.Blur() }
 func (t *TextField) View() string { return t.Model.View() }
 


### PR DESCRIPTION
## Summary
- add ReadOnly and SetReadOnly to Field interface
- simplify IsFocused to use ReadOnly instead of type switch
- gate TextField and CheckField focus when read-only

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6893971b9e58832498ba117b69f05287