### PR TITLE
style: gray read-only form fields

### DIFF
--- a/ui/form_check.go
+++ b/ui/form_check.go
@@ -48,10 +48,14 @@ func (c *CheckField) View() string {
 	if c.value {
 		box = "[x]"
 	}
-	if c.focused {
+	switch {
+	case c.readOnly:
+		return BlurredStyle.Render(box)
+	case c.focused:
 		return FocusedStyle.Render(box)
+	default:
+		return box
 	}
-	return box
 }
 
 func (c *CheckField) Value() string { return fmt.Sprintf("%v", c.value) }

--- a/ui/form_select.go
+++ b/ui/form_select.go
@@ -69,10 +69,14 @@ func (s *SelectField) Update(msg tea.Msg) tea.Cmd {
 
 func (s *SelectField) View() string {
 	val := s.options[s.Index]
-	if s.focused {
+	switch {
+	case s.readOnly:
+		return BlurredStyle.Render(val)
+	case s.focused:
 		return FocusedStyle.Render(val)
+	default:
+		return val
 	}
-	return val
 }
 
 func (s *SelectField) Value() string { return s.options[s.Index] }


### PR DESCRIPTION
## Summary
- tint select and checkbox fields gray when read-only
- reuse existing gray style for disabled look

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68939784cabc8324a94898f36260306a