### PR TITLE
Handle select fields without options

### DIFF
--- a/connections/form.go
+++ b/connections/form.go
@@ -109,7 +109,11 @@ func NewForm(p Profile, idx int) Form {
 		case ftBool:
 			fields[i] = ui.NewCheckField(boolVal)
 		case ftSelect:
-			fields[i] = ui.NewSelectField(strVal, fd.options)
+			sf, err := ui.NewSelectField(strVal, fd.options)
+			if err != nil {
+				sf = &ui.SelectField{}
+			}
+			fields[i] = sf
 		case ftPassword:
 			fields[i] = ui.NewTextField(strVal, placeholder, true)
 		default:

--- a/traces/traceform.go
+++ b/traces/traceform.go
@@ -26,12 +26,18 @@ const (
 // newTraceForm builds a form for creating or editing a trace.
 func newTraceForm(profiles []string, current string, topics []string) traceForm {
 	keyField := ui.NewTextField("", "Key")
-	profileField := ui.NewSelectField(current, profiles)
+	profileField, err := ui.NewSelectField(current, profiles)
+	if err != nil {
+		profileField = &ui.SelectField{}
+	}
 	topicsField := ui.NewTextField(strings.Join(topics, ","), "Topics")
 	startField := ui.NewTextField("", "2006-01-02T15:04:05Z")
 	endField := ui.NewTextField("", "2006-01-02T15:04:05Z")
 	fields := []ui.Field{keyField, profileField, topicsField, startField, endField}
 	tf := traceForm{Form: ui.Form{Fields: fields, Focus: 0}}
+	if err != nil {
+		tf.errMsg = err.Error()
+	}
 	tf.ApplyFocus()
 	return tf
 }

--- a/ui/form_select.go
+++ b/ui/form_select.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -17,7 +18,10 @@ type SelectField struct {
 	readOnly bool
 }
 
-func NewSelectField(val string, opts []string) *SelectField {
+func NewSelectField(val string, opts []string) (*SelectField, error) {
+	if len(opts) == 0 {
+		return nil, fmt.Errorf("no options provided")
+	}
 	idx := 0
 	for i, o := range opts {
 		if o == val {
@@ -25,7 +29,7 @@ func NewSelectField(val string, opts []string) *SelectField {
 			break
 		}
 	}
-	return &SelectField{options: opts, Index: idx}
+	return &SelectField{options: opts, Index: idx}, nil
 }
 
 func (s *SelectField) Focus() {
@@ -68,6 +72,13 @@ func (s *SelectField) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (s *SelectField) View() string {
+	if len(s.options) == 0 {
+		val := "-"
+		if s.focused {
+			return FocusedStyle.Render(val)
+		}
+		return BlurredStyle.Render(val)
+	}
 	val := s.options[s.Index]
 	if s.focused {
 		return FocusedStyle.Render(val)
@@ -75,7 +86,12 @@ func (s *SelectField) View() string {
 	return val
 }
 
-func (s *SelectField) Value() string { return s.options[s.Index] }
+func (s *SelectField) Value() string {
+	if len(s.options) == 0 {
+		return ""
+	}
+	return s.options[s.Index]
+}
 
 // OptionsView renders the available options when the field is focused.
 // The current selection is highlighted.

--- a/ui/form_select_test.go
+++ b/ui/form_select_test.go
@@ -1,0 +1,24 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewSelectFieldNoOptions(t *testing.T) {
+	sf, err := NewSelectField("", nil)
+	if err == nil || sf != nil {
+		t.Fatalf("expected error for empty options")
+	}
+}
+
+func TestSelectFieldEmptyOptions(t *testing.T) {
+	sf := &SelectField{}
+	if v := sf.Value(); v != "" {
+		t.Fatalf("expected empty value, got %q", v)
+	}
+	view := sf.View()
+	if !strings.Contains(view, "-") {
+		t.Fatalf("expected placeholder in view, got %q", view)
+	}
+}


### PR DESCRIPTION
## Summary
- validate options list in `NewSelectField` and return an error if empty
- show a placeholder and empty value when a select field has no options
- update trace and connection forms and add tests for empty select fields

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68939745dad88324b3b9a5c0ed374825