### PR TITLE
Handle unknown topic actions

### DIFF
--- a/update_client.go
+++ b/update_client.go
@@ -2,7 +2,6 @@ package emqutiti
 
 import (
 	"fmt"
-	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	connections "github.com/marang/emqutiti/connections"
@@ -18,17 +17,26 @@ func (m *model) logTopicAction(topic, action string, err error) {
 		m.history.Append(topic, "", "log", fmt.Sprintf("No action specified for topic: %s", topic))
 		return
 	}
-	act := strings.ToUpper(action[:1]) + action[1:]
-	if err != nil {
-		m.history.Append(topic, "", "log", fmt.Sprintf("%s error for %s: %v", act, topic, err))
-		return
-	}
+
+	var label, success string
 	switch action {
 	case "subscribe":
-		m.history.Append(topic, "", "log", fmt.Sprintf("Subscribed to topic: %s", topic))
+		label = "Subscribe"
+		success = "Subscribed to topic: %s"
 	case "unsubscribe":
-		m.history.Append(topic, "", "log", fmt.Sprintf("Unsubscribed from topic: %s", topic))
+		label = "Unsubscribe"
+		success = "Unsubscribed from topic: %s"
+	default:
+		m.history.Append(topic, "", "log", fmt.Sprintf("Unknown action for topic: %s", topic))
+		return
 	}
+
+	if err != nil {
+		m.history.Append(topic, "", "log", fmt.Sprintf("%s error for %s: %v", label, topic, err))
+		return
+	}
+
+	m.history.Append(topic, "", "log", fmt.Sprintf(success, topic))
 }
 
 // handleTopicToggle subscribes or unsubscribes from a topic and logs the action.

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -176,4 +176,17 @@ func TestLogTopicAction(t *testing.T) {
 			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
 		}
 	})
+
+	t.Run("unknown", func(t *testing.T) {
+		m, _ := initialModel(nil)
+		m.logTopicAction("t1", "invalid", nil)
+		items := m.history.Items()
+		if len(items) != 1 {
+			t.Fatalf("expected 1 history item, got %d", len(items))
+		}
+		exp := "Unknown action for topic: t1"
+		if items[0].Kind != "log" || items[0].Payload != exp {
+			t.Fatalf("unexpected log item: kind %q payload %q", items[0].Kind, items[0].Payload)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- ensure topic action logs use explicit labels and handle unknown actions
- test logging for subscribe, unsubscribe, and unknown actions

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896569d3a1883248d50afec36cb492b