### PR TITLE
mark retained messages in history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@
   `keyring_util_test.go` requires a real keyring and is skipped by default.
 
 ## Agent Notes
-The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter`, or use `Ctrl+Shift+S` to retain them, when the message field is focused. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name. The importer code lives in the main package and runs via these flags.
+The TUI runs fullscreen with colorful borders. Press `Ctrl+B` to open the broker manager to add, edit, or delete MQTT profiles. Passwords are stored securely using the system keyring. Publish messages with `Ctrl+S` or `Ctrl+Enter`, or use `Ctrl+Shift+S` to retain them, when the message field is focused. History labels retained messages. Use the `--import`/`-i` flag to launch an interactive wizard for CSV or XLS bulk publishing and select a connection with `--profile` or `-p`. The wizard lets you rename columns when mapping them to JSON fields. Leaving a mapping blank keeps the original column name. The importer code lives in the main package and runs via these flags.
 Press `Ctrl+D` from any screen to exit the program.
 Scroll with `Ctrl+Up`/`Ctrl+Down` or `Ctrl+K`/`Ctrl+J`. In history,
 `a` archives messages and `Delete` removes them.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Tips:
 | Ctrl+F | Clear all history filters |
 | Enter | View full message |
 
+Retained messages are labeled "(retained)".
+
 ## License
 
 This project is licensed under the terms of the MIT License. See [LICENSE](LICENSE) for details.

--- a/client_keys.go
+++ b/client_keys.go
@@ -134,7 +134,7 @@ func (m *model) publishMessage(retained bool) {
 		if retained {
 			msg = fmt.Sprintf("Published retained to %s: %s", topic, payload)
 		}
-		m.history.Append(topic, payload, "pub", msg)
+		m.history.Append(topic, payload, "pub", retained, msg)
 		if m.mqttClient != nil {
 			m.mqttClient.Publish(topic, 0, retained, payload)
 		}

--- a/client_keys_history.go
+++ b/client_keys_history.go
@@ -29,14 +29,14 @@ func (m *model) copyHistoryItems(items []history.Item) (int, error) {
 		return 0, nil
 	}
 	if err := clipboard.WriteAll(strings.Join(parts, "\n")); err != nil {
-		m.history.Append("", err.Error(), "log", err.Error())
+		m.history.Append("", err.Error(), "log", false, err.Error())
 		return 0, err
 	}
 	msg := "Copied item"
 	if len(parts) > 1 {
 		msg = fmt.Sprintf("Copied %d item(s)", len(parts))
 	}
-	m.history.Append("", msg, "log", msg)
+	m.history.Append("", msg, "log", false, msg)
 	return len(parts), nil
 }
 

--- a/client_keys_history_manage.go
+++ b/client_keys_history_manage.go
@@ -49,7 +49,7 @@ func (m *model) handleArchiveKey() tea.Cmd {
 					if err := st.Archive(key); err != nil {
 						msg := fmt.Sprintf("Failed to archive message: %v", err)
 						log.Println(msg)
-						m.history.Append("", msg, "log", msg)
+						m.history.Append("", msg, "log", false, msg)
 						continue
 					}
 				}
@@ -66,7 +66,7 @@ func (m *model) handleArchiveKey() tea.Cmd {
 					if err := st.Archive(key); err != nil {
 						msg := fmt.Sprintf("Failed to archive message: %v", err)
 						log.Println(msg)
-						m.history.Append("", msg, "log", msg)
+						m.history.Append("", msg, "log", false, msg)
 					} else {
 						hitems = append(hitems[:idx], hitems[idx+1:]...)
 					}
@@ -126,7 +126,7 @@ func (m *model) handleDeleteHistoryKey() tea.Cmd {
 					if err := st.Delete(key); err != nil {
 						msg := fmt.Sprintf("Failed to delete message: %v", err)
 						log.Println(msg)
-						m.history.Append("", msg, "log", msg)
+						m.history.Append("", msg, "log", false, msg)
 						continue
 					}
 				}

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -93,7 +93,7 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 	switch msg.String() {
 	case constants.KeyCtrlB:
 		if err := m.connections.Manager.LoadProfiles(""); err != nil {
-			m.history.Append("", err.Error(), "log", err.Error())
+			m.history.Append("", err.Error(), "log", false, err.Error())
 		}
 		m.connections.RefreshConnectionItems()
 		m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())

--- a/client_publish_test.go
+++ b/client_publish_test.go
@@ -83,4 +83,8 @@ func TestHandlePublishRetainKey(t *testing.T) {
 	if !fc.retained {
 		t.Fatalf("expected retained publish")
 	}
+	items := m.history.Items()
+	if len(items) == 0 || !items[len(items)-1].Retained {
+		t.Fatalf("expected history item marked retained")
+	}
 }

--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -106,7 +106,7 @@ func (m *model) HandleConnectResult(msg connections.ConnectResult) {
 		hitems := make([]history.Item, len(msgs))
 		items := make([]list.Item, len(msgs))
 		for i, mmsg := range msgs {
-			hi := history.Item{Timestamp: mmsg.Timestamp, Topic: mmsg.Topic, Payload: mmsg.Payload, Kind: mmsg.Kind, Archived: mmsg.Archived}
+			hi := history.Item{Timestamp: mmsg.Timestamp, Topic: mmsg.Topic, Payload: mmsg.Payload, Kind: mmsg.Kind, Archived: mmsg.Archived, Retained: mmsg.Retained}
 			hitems[i] = hi
 			items[i] = hi
 		}

--- a/help/help.md
+++ b/help/help.md
@@ -64,6 +64,8 @@
 | Ctrl+F | Clear all history filters |
 | Enter | View full message |
 
+Retained messages are labeled "(retained)".
+
 ## Traces manager
 
 | Key | Action |

--- a/history/history_component.go
+++ b/history/history_component.go
@@ -138,15 +138,15 @@ func (h *Component) ViewFilter() string {
 func (h *Component) Focusables() map[string]Focusable { return map[string]Focusable{} }
 
 // Append stores a message in the history list and optional store.
-func (h *Component) Append(topic, payload, kind, logText string) {
+func (h *Component) Append(topic, payload, kind string, retained bool, logText string) {
 	ts := time.Now()
 	text := payload
 	if kind == "log" {
 		text = logText
 	}
-	hi := Item{Timestamp: ts, Topic: topic, Payload: text, Kind: kind, Archived: false}
+	hi := Item{Timestamp: ts, Topic: topic, Payload: text, Kind: kind, Archived: false, Retained: retained}
 	if h.store != nil {
-		h.store.Append(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false})
+		h.store.Append(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false, Retained: retained})
 	}
 	if !h.showArchived {
 		if h.filterQuery != "" {

--- a/history/history_delegate.go
+++ b/history/history_delegate.go
@@ -51,6 +51,9 @@ func (d historyDelegate) Render(w io.Writer, m list.Model, index int, item list.
 		lblColor = ui.ColGray
 		msgColor = ui.ColGray
 	}
+	if hi.Retained && hi.Kind != "log" {
+		label += " (retained)"
+	}
 	align := lipgloss.Left
 	if hi.Kind == "pub" {
 		align = lipgloss.Right

--- a/history/history_util.go
+++ b/history/history_util.go
@@ -14,6 +14,7 @@ func MessagesToItems(msgs []Message) ([]Item, []list.Item) {
 			Payload:   m.Payload,
 			Kind:      m.Kind,
 			Archived:  m.Archived,
+			Retained:  m.Retained,
 		}
 		hitems[i] = hi
 		litems[i] = hi

--- a/history/history_util_test.go
+++ b/history/history_util_test.go
@@ -8,8 +8,8 @@ import (
 // TestMessagesToItems verifies conversion from Message slices to history items.
 func TestMessagesToItems(t *testing.T) {
 	msgs := []Message{
-		{Timestamp: time.Unix(0, 1), Topic: "t1", Payload: "p1", Kind: "pub", Archived: false},
-		{Timestamp: time.Unix(0, 2), Topic: "t2", Payload: "p2", Kind: "sub", Archived: true},
+		{Timestamp: time.Unix(0, 1), Topic: "t1", Payload: "p1", Kind: "pub", Archived: false, Retained: true},
+		{Timestamp: time.Unix(0, 2), Topic: "t2", Payload: "p2", Kind: "sub", Archived: true, Retained: false},
 	}
 	hitems, litems := MessagesToItems(msgs)
 	if len(hitems) != len(msgs) {
@@ -20,7 +20,7 @@ func TestMessagesToItems(t *testing.T) {
 	}
 	for i, hi := range hitems {
 		m := msgs[i]
-		if hi.Timestamp != m.Timestamp || hi.Topic != m.Topic || hi.Payload != m.Payload || hi.Kind != m.Kind || hi.Archived != m.Archived {
+		if hi.Timestamp != m.Timestamp || hi.Topic != m.Topic || hi.Payload != m.Payload || hi.Kind != m.Kind || hi.Archived != m.Archived || hi.Retained != m.Retained {
 			t.Fatalf("item %d mismatch: %#v vs %#v", i, hi, m)
 		}
 		if li, ok := litems[i].(Item); ok {

--- a/history/historystore.go
+++ b/history/historystore.go
@@ -20,6 +20,7 @@ type Message struct {
 	Payload   string
 	Kind      string
 	Archived  bool
+	Retained  bool
 }
 
 // store stores messages in memory and optionally persists them to disk.

--- a/history/historystore_archive_test.go
+++ b/history/historystore_archive_test.go
@@ -9,7 +9,7 @@ import (
 func TestArchiveAndSearch(t *testing.T) {
 	hs := &store{}
 	ts := time.Now()
-	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub"}
+	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub", Retained: false}
 	hs.Append(msg)
 	key := fmt.Sprintf("%s/%020d", msg.Topic, msg.Timestamp.UnixNano())
 	if err := hs.Archive(key); err != nil {

--- a/history/historystore_query_test.go
+++ b/history/historystore_query_test.go
@@ -82,8 +82,8 @@ func TestParseQuery(t *testing.T) {
 func TestApplyFilterArchived(t *testing.T) {
 	hs := &store{}
 	ts := time.Now()
-	hs.Append(Message{Timestamp: ts, Topic: "t1", Payload: "active", Kind: "pub"})
-	hs.Append(Message{Timestamp: ts.Add(time.Second), Topic: "t2", Payload: "arch", Kind: "pub", Archived: true})
+	hs.Append(Message{Timestamp: ts, Topic: "t1", Payload: "active", Kind: "pub", Retained: false})
+	hs.Append(Message{Timestamp: ts.Add(time.Second), Topic: "t2", Payload: "arch", Kind: "pub", Archived: true, Retained: false})
 
 	items, _ := ApplyFilter("", hs, false)
 	if len(items) != 1 || items[0].Archived {

--- a/history/historystore_search_test.go
+++ b/history/historystore_search_test.go
@@ -12,8 +12,8 @@ func TestHistoryStoreSearch(t *testing.T) {
 
 	t.Run("active", func(t *testing.T) {
 		hs := &store{}
-		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub"})
-		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub"})
+		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Retained: false})
+		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Retained: false})
 
 		res := hs.Search(false, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {
@@ -33,8 +33,8 @@ func TestHistoryStoreSearch(t *testing.T) {
 
 	t.Run("archived", func(t *testing.T) {
 		hs := &store{}
-		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true})
-		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true})
+		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true, Retained: false})
+		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true, Retained: false})
 
 		res := hs.Search(true, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {

--- a/history/item.go
+++ b/history/item.go
@@ -16,6 +16,7 @@ type Item struct {
 	Payload             string
 	Kind                string // pub, sub, log
 	Archived            bool
+	Retained            bool
 	IsSelected          *bool
 	IsMarkedForDeletion *bool
 }
@@ -37,6 +38,9 @@ func (h Item) Title() string {
 	default:
 		label = "LOG"
 		color = ui.ColGray
+	}
+	if h.Retained {
+		label += " (retained)"
 	}
 	return lipgloss.NewStyle().Foreground(color).Render(
 		fmt.Sprintf("%s %s: %s", label, h.Topic, h.Payload),

--- a/mqttclient.go
+++ b/mqttclient.go
@@ -14,8 +14,9 @@ import (
 const defaultTokenTimeout = 5 * time.Second
 
 type MQTTMessage struct {
-	Topic   string
-	Payload string
+	Topic    string
+	Payload  string
+	Retained bool
 }
 
 type MQTTClient struct {
@@ -111,7 +112,7 @@ func NewMQTTClient(p connections.Profile, fn statusFunc) (*MQTTClient, error) {
 
 	msgChan := make(chan MQTTMessage, 20)
 	opts.SetDefaultPublishHandler(func(client mqtt.Client, m mqtt.Message) {
-		msgChan <- MQTTMessage{Topic: m.Topic(), Payload: string(m.Payload())}
+		msgChan <- MQTTMessage{Topic: m.Topic(), Payload: string(m.Payload()), Retained: m.Retained()}
 	})
 
 	client := mqtt.NewClient(opts)

--- a/status.go
+++ b/status.go
@@ -11,7 +11,7 @@ import (
 
 // handleStatusMessage processes broker status updates.
 func (m *model) handleStatusMessage(msg connections.StatusMessage) tea.Cmd {
-	m.history.Append("", string(msg), "log", string(msg))
+	m.history.Append("", string(msg), "log", false, string(msg))
 	if strings.HasPrefix(string(msg), "Connected") && m.connections.Active != "" {
 		m.connections.SetConnected(m.connections.Active)
 		m.connections.RefreshConnectionItems()
@@ -25,7 +25,7 @@ func (m *model) handleStatusMessage(msg connections.StatusMessage) tea.Cmd {
 
 // handleMQTTMessage appends received MQTT messages to history.
 func (m *model) handleMQTTMessage(msg MQTTMessage) tea.Cmd {
-	m.history.Append(msg.Topic, msg.Payload, "sub", fmt.Sprintf("Received on %s: %s", msg.Topic, msg.Payload))
+	m.history.Append(msg.Topic, msg.Payload, "sub", msg.Retained, fmt.Sprintf("Received on %s: %s", msg.Topic, msg.Payload))
 	return listenMessages(m.mqttClient.MessageChan)
 }
 

--- a/traces/api.go
+++ b/traces/api.go
@@ -28,7 +28,7 @@ type API interface {
 	Profiles() []connections.Profile
 	ActiveConnection() string
 	SubscribedTopics() []string
-	LogHistory(topic, payload, kind, text string)
+	LogHistory(topic, payload, kind string, retained bool, text string)
 	TraceHeight() int
 	SetTraceHeight(int)
 	Width() int

--- a/traces/component.go
+++ b/traces/component.go
@@ -243,10 +243,10 @@ func (t *Component) Update(msg tea.Msg) tea.Cmd {
 						}
 						t.list.SetItems(items)
 						if err := t.store.RemoveTrace(key); err != nil {
-							t.api.LogHistory("", err.Error(), "log", err.Error())
+							t.api.LogHistory("", err.Error(), "log", false, err.Error())
 						}
 						if err := t.store.ClearData(cfg.Profile, key); err != nil {
-							t.api.LogHistory("", err.Error(), "log", err.Error())
+							t.api.LogHistory("", err.Error(), "log", false, err.Error())
 						}
 						if t.anyTraceRunning() {
 							return traceTicker()

--- a/traces/message.go
+++ b/traces/message.go
@@ -8,4 +8,5 @@ type TracerMessage struct {
 	Topic     string
 	Payload   string
 	Kind      string
+	Retained  bool
 }

--- a/traces/runtime.go
+++ b/traces/runtime.go
@@ -124,7 +124,7 @@ func (t *Tracer) Start() error {
 				if ts.Before(t.cfg.Start) {
 					return
 				}
-				if err := tracerAddDB(db, t.cfg.Key, TracerMessage{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace"}); err != nil {
+				if err := tracerAddDB(db, t.cfg.Key, TracerMessage{Timestamp: ts, Topic: m.Topic(), Payload: string(m.Payload()), Kind: "trace", Retained: m.Retained()}); err != nil {
 					t.reportErr(fmt.Errorf("tracerAdd: %w", err))
 					return
 				}

--- a/traces/store_test.go
+++ b/traces/store_test.go
@@ -58,7 +58,7 @@ func TestTracerAddError(t *testing.T) {
 	jsonMarshal = func(any) ([]byte, error) { return nil, errors.New("fail") }
 	defer func() { jsonMarshal = old }()
 
-	err := tracerAdd("test", "k1", TracerMessage{Timestamp: time.Now()})
+	err := tracerAdd("test", "k1", TracerMessage{Timestamp: time.Now(), Retained: false})
 	if err == nil {
 		t.Fatalf("expected error")
 	}

--- a/traces_api_impl.go
+++ b/traces_api_impl.go
@@ -30,8 +30,8 @@ func (m *model) SubscribedTopics() []string {
 	return topics
 }
 
-func (m *model) LogHistory(topic, payload, kind, text string) {
-	m.history.Append(topic, payload, kind, text)
+func (m *model) LogHistory(topic, payload, kind string, retained bool, text string) {
+	m.history.Append(topic, payload, kind, retained, text)
 }
 
 func (m *model) TraceHeight() int { return m.layout.trace.height }

--- a/update_client.go
+++ b/update_client.go
@@ -14,7 +14,7 @@ import (
 // An empty action logs a no-op message.
 func (m *model) logTopicAction(topic, action string, err error) {
 	if len(action) == 0 {
-		m.history.Append(topic, "", "log", fmt.Sprintf("No action specified for topic: %s", topic))
+		m.history.Append(topic, "", "log", false, fmt.Sprintf("No action specified for topic: %s", topic))
 		return
 	}
 
@@ -27,16 +27,16 @@ func (m *model) logTopicAction(topic, action string, err error) {
 		label = "Unsubscribe"
 		success = "Unsubscribed from topic: %s"
 	default:
-		m.history.Append(topic, "", "log", fmt.Sprintf("Unknown action for topic: %s", topic))
+		m.history.Append(topic, "", "log", false, fmt.Sprintf("Unknown action for topic: %s", topic))
 		return
 	}
 
 	if err != nil {
-		m.history.Append(topic, "", "log", fmt.Sprintf("%s error for %s: %v", label, topic, err))
+		m.history.Append(topic, "", "log", false, fmt.Sprintf("%s error for %s: %v", label, topic, err))
 		return
 	}
 
-	m.history.Append(topic, "", "log", fmt.Sprintf(success, topic))
+	m.history.Append(topic, "", "log", false, fmt.Sprintf(success, topic))
 }
 
 // handleTopicToggle subscribes or unsubscribes from a topic and logs the action.

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -78,9 +78,9 @@ func setupManyTopics(m *model, n int) {
 func TestHandleHistorySelectionShift(t *testing.T) {
 	m, _ := initialModel(nil)
 	m.history.SetItems([]history.Item{
-		{Timestamp: time.Now(), Topic: "t1", Payload: "p1", Kind: "pub"},
-		{Timestamp: time.Now(), Topic: "t2", Payload: "p2", Kind: "pub"},
-		{Timestamp: time.Now(), Topic: "t3", Payload: "p3", Kind: "pub"},
+		{Timestamp: time.Now(), Topic: "t1", Payload: "p1", Kind: "pub", Retained: false},
+		{Timestamp: time.Now(), Topic: "t2", Payload: "p2", Kind: "pub", Retained: false},
+		{Timestamp: time.Now(), Topic: "t3", Payload: "p3", Kind: "pub", Retained: false},
 	})
 	items := make([]list.Item, len(m.history.Items()))
 	for i, it := range m.history.Items() {
@@ -109,8 +109,8 @@ func TestFilterHistoryList(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
+	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
 
 	m.history.List().SetFilteringEnabled(true)
 	m.history.List().SetFilterText("topic=foo")
@@ -130,7 +130,7 @@ func TestFilterHistoryList(t *testing.T) {
 func TestHandleHistoryClick(t *testing.T) {
 	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
-	m.history.SetItems([]history.Item{{Timestamp: time.Now(), Topic: "t1", Payload: "p1", Kind: "pub"}})
+	m.history.SetItems([]history.Item{{Timestamp: time.Now(), Topic: "t1", Payload: "p1", Kind: "pub", Retained: false}})
 	items := []list.Item{m.history.Items()[0]}
 	m.history.List().SetItems(items)
 	m.viewClient()
@@ -145,7 +145,7 @@ func TestHandleHistoryClick(t *testing.T) {
 func TestHistoryScroll(t *testing.T) {
 	m, _ := initialModel(nil)
 	for i := 0; i < 30; i++ {
-		hi := history.Item{Timestamp: time.Now(), Topic: fmt.Sprintf("t%d", i), Payload: "p", Kind: "pub"}
+		hi := history.Item{Timestamp: time.Now(), Topic: fmt.Sprintf("t%d", i), Payload: "p", Kind: "pub", Retained: false}
 		m.history.SetItems(append(m.history.Items(), hi))
 	}
 	items := make([]list.Item, len(m.history.Items()))

--- a/update_client_test.go
+++ b/update_client_test.go
@@ -48,7 +48,7 @@ func (c *failingClient) OptionsReader() mqtt.ClientOptionsReader {
 func TestHandleClientKeyCopySelected(t *testing.T) {
 	m, _ := initialModel(nil)
 	sel := true
-	hi := history.Item{Timestamp: time.Now(), Topic: "t1", Payload: "msg1", Kind: "pub", IsSelected: &sel}
+	hi := history.Item{Timestamp: time.Now(), Topic: "t1", Payload: "msg1", Kind: "pub", Retained: false, IsSelected: &sel}
 	m.history.SetItems([]history.Item{hi})
 	m.history.List().SetItems([]list.Item{hi})
 	m.history.List().Select(0)

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -16,7 +16,7 @@ func TestUpdateHistoryFilter(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -38,8 +38,8 @@ func TestHistoryFilterPersists(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
+	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -69,8 +69,8 @@ func TestHistoryFilterUpdatesCounts(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub"})
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
+	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -91,8 +91,8 @@ func TestHistoryFilterArchived(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub"})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Archived: true})
+	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
+	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Archived: true, Retained: false})
 
 	// default unchecked state shows unarchived messages
 	m.startHistoryFilter()

--- a/viewport_scroll_test.go
+++ b/viewport_scroll_test.go
@@ -10,7 +10,7 @@ func TestViewportScrollCtrlJ(t *testing.T) {
 	m, _ := initialModel(nil)
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 10})
 	for i := 0; i < 50; i++ {
-		m.history.Append("t", "msg", "pub", "")
+		m.history.Append("t", "msg", "pub", false, "")
 	}
 	m.viewClient()
 	if m.ui.viewport.YOffset != 0 {


### PR DESCRIPTION
## Summary
- mark retained publishes and deliveries in history
- track retain flag from MQTT messages
- note retained markers in help text

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68965cfa66a08324a55c88bb94ae56b9