### PR TITLE
handle history store errors

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -193,7 +193,11 @@ func initImporter(m *model) error {
 func initialModel(conns *connections.Connections) (*model, error) {
 	order := append([]string(nil), focusByMode[constants.ModeClient]...)
 	cs, loadErr := initConnections(conns)
-	st, _ := history.OpenStore("")
+	st, err := history.OpenStore("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "history store error: %v\n", err)
+		st = nil
+	}
 	ms := initMessage()
 	tr := traces.Init()
 	m := &model{


### PR DESCRIPTION
## Summary
- handle errors when opening history store; log to stderr and fall back to in-memory store

## Testing
- `go vet -v ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896f8e4f4948324b743f5e18f174078