### PR TITLE
Improve history store error handling

### DIFF
--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -100,7 +100,10 @@ func (m *model) HandleConnectResult(msg connections.ConnectResult) {
 	if st := m.history.Store(); st != nil {
 		st.Close()
 	}
-	if idx, err := history.OpenStore(profile.Name); err == nil {
+	idx, err := history.OpenStore(profile.Name)
+	if err != nil {
+		m.connections.SendStatus(fmt.Sprintf("History open error for %s: %v", profile.Name, err))
+	} else {
 		m.history.SetStore(idx)
 		msgs := idx.Search(false, nil, time.Time{}, time.Time{}, "")
 		hitems := make([]history.Item, len(msgs))

--- a/history/api.go
+++ b/history/api.go
@@ -27,7 +27,7 @@ type Model interface {
 
 // Store defines operations for storing and querying history messages.
 type Store interface {
-	Append(Message)
+	Append(Message) error
 	Search(archived bool, topics []string, start, end time.Time, payload string) []Message
 	Delete(key string) error
 	Archive(key string) error

--- a/history/history_component.go
+++ b/history/history_component.go
@@ -1,6 +1,7 @@
 package history
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -146,7 +147,9 @@ func (h *Component) Append(topic, payload, kind string, retained bool, logText s
 	}
 	hi := Item{Timestamp: ts, Topic: topic, Payload: text, Kind: kind, Archived: false, Retained: retained}
 	if h.store != nil {
-		h.store.Append(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false, Retained: retained})
+		if err := h.store.Append(Message{Timestamp: ts, Topic: topic, Payload: payload, Kind: kind, Archived: false, Retained: retained}); err != nil {
+			fmt.Printf("history append error: %v\n", err)
+		}
 	}
 	if !h.showArchived {
 		if h.filterQuery != "" {

--- a/history/historystore_archive_test.go
+++ b/history/historystore_archive_test.go
@@ -10,7 +10,9 @@ func TestArchiveAndSearch(t *testing.T) {
 	hs := &store{}
 	ts := time.Now()
 	msg := Message{Timestamp: ts, Topic: "t1", Payload: "p1", Kind: "pub", Retained: false}
-	hs.Append(msg)
+	if err := hs.Append(msg); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 	key := fmt.Sprintf("%s/%020d", msg.Topic, msg.Timestamp.UnixNano())
 	if err := hs.Archive(key); err != nil {
 		t.Fatalf("Archive failed: %v", err)

--- a/history/historystore_query_test.go
+++ b/history/historystore_query_test.go
@@ -82,8 +82,12 @@ func TestParseQuery(t *testing.T) {
 func TestApplyFilterArchived(t *testing.T) {
 	hs := &store{}
 	ts := time.Now()
-	hs.Append(Message{Timestamp: ts, Topic: "t1", Payload: "active", Kind: "pub", Retained: false})
-	hs.Append(Message{Timestamp: ts.Add(time.Second), Topic: "t2", Payload: "arch", Kind: "pub", Archived: true, Retained: false})
+	if err := hs.Append(Message{Timestamp: ts, Topic: "t1", Payload: "active", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	if err := hs.Append(Message{Timestamp: ts.Add(time.Second), Topic: "t2", Payload: "arch", Kind: "pub", Archived: true, Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	items, _ := ApplyFilter("", hs, false)
 	if len(items) != 1 || items[0].Archived {

--- a/history/historystore_search_test.go
+++ b/history/historystore_search_test.go
@@ -12,8 +12,12 @@ func TestHistoryStoreSearch(t *testing.T) {
 
 	t.Run("active", func(t *testing.T) {
 		hs := &store{}
-		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Retained: false})
-		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Retained: false})
+		if err := hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Retained: false}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+		if err := hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Retained: false}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
 
 		res := hs.Search(false, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {
@@ -33,8 +37,12 @@ func TestHistoryStoreSearch(t *testing.T) {
 
 	t.Run("archived", func(t *testing.T) {
 		hs := &store{}
-		hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true, Retained: false})
-		hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true, Retained: false})
+		if err := hs.Append(Message{Timestamp: now.Add(-30 * time.Minute), Topic: "a", Payload: "foo", Kind: "pub", Archived: true, Retained: false}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+		if err := hs.Append(Message{Timestamp: now.Add(-2 * time.Hour), Topic: "b", Payload: "bar", Kind: "pub", Archived: true, Retained: false}); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
 
 		res := hs.Search(true, []string{"a"}, now.Add(-1*time.Hour), now, "")
 		if len(res) != 1 || res[0].Topic != "a" {

--- a/model_history.go
+++ b/model_history.go
@@ -99,7 +99,10 @@ func (f historyFilterForm) View() string {
 // historyStore provides an in-memory implementation of history.Store for tests.
 type historyStore struct{ msgs []history.Message }
 
-func (s *historyStore) Append(m history.Message) { s.msgs = append(s.msgs, m) }
+func (s *historyStore) Append(m history.Message) error {
+	s.msgs = append(s.msgs, m)
+	return nil
+}
 
 func (s *historyStore) Search(archived bool, topics []string, start, end time.Time, payload string) []history.Message {
 	var out []history.Message

--- a/model_init.go
+++ b/model_init.go
@@ -193,7 +193,10 @@ func initImporter(m *model) error {
 func initialModel(conns *connections.Connections) (*model, error) {
 	order := append([]string(nil), focusByMode[constants.ModeClient]...)
 	cs, loadErr := initConnections(conns)
-	st, _ := history.OpenStore("")
+	st, err := history.OpenStore("")
+	if err != nil && loadErr == nil {
+		loadErr = err
+	}
 	ms := initMessage()
 	tr := traces.Init()
 	m := &model{

--- a/run_test.go
+++ b/run_test.go
@@ -50,7 +50,7 @@ func (s *stubMQTTClient) Disconnect() { s.disconnected = true }
 
 type stubHistoryStore struct{ closed bool }
 
-func (s *stubHistoryStore) Append(history.Message) {}
+func (s *stubHistoryStore) Append(history.Message) error { return nil }
 func (s *stubHistoryStore) Search(bool, []string, time.Time, time.Time, string) []history.Message {
 	return nil
 }

--- a/traces/history_mem_store.go
+++ b/traces/history_mem_store.go
@@ -15,7 +15,7 @@ func newMemStore(msgs []history.Message) *memStore {
 	return &memStore{msgs: msgs}
 }
 
-func (m *memStore) Append(history.Message) {}
+func (m *memStore) Append(history.Message) error { return nil }
 
 func (m *memStore) Search(archived bool, topics []string, start, end time.Time, payload string) []history.Message {
 	var out []history.Message

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -109,8 +109,12 @@ func TestFilterHistoryList(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	m.history.List().SetFilteringEnabled(true)
 	m.history.List().SetFilterText("topic=foo")

--- a/update_history_filter_test.go
+++ b/update_history_filter_test.go
@@ -16,7 +16,9 @@ func TestUpdateHistoryFilter(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -38,8 +40,12 @@ func TestHistoryFilterPersists(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -69,8 +75,12 @@ func TestHistoryFilterUpdatesCounts(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false})
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	m.startHistoryFilter()
 	m.history.FilterForm().Topic().SetValue("foo")
@@ -91,8 +101,12 @@ func TestHistoryFilterArchived(t *testing.T) {
 	hs := &historyStore{}
 	m.history.SetStore(hs)
 	ts := time.Now()
-	hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false})
-	hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Archived: true, Retained: false})
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "foo", Payload: "hello", Kind: "pub", Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	if err := hs.Append(history.Message{Timestamp: ts, Topic: "bar", Payload: "bye", Kind: "pub", Archived: true, Retained: false}); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
 
 	// default unchecked state shows unarchived messages
 	m.startHistoryFilter()


### PR DESCRIPTION
## Summary
- propagate Badger view and value errors when opening the history store
- return errors from history store append/archive operations and log failures
- surface history store open errors in model initialization and connection handling

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6896f8f86cec8324bc4e7a17915856ed