### PR TITLE
Surface history store errors

### DIFF
--- a/model_init.go
+++ b/model_init.go
@@ -193,12 +193,12 @@ func initImporter(m *model) error {
 func initialModel(conns *connections.Connections) (*model, error) {
 	order := append([]string(nil), focusByMode[constants.ModeClient]...)
 	cs, loadErr := initConnections(conns)
-	st, err := history.OpenStore("")
-	if err != nil && loadErr == nil {
-		loadErr = err
-  }
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "history store error: %v\n", err)
+	st, herr := history.OpenStore("")
+	if herr != nil && loadErr == nil {
+		loadErr = herr
+	}
+	if herr != nil {
+		fmt.Fprintf(os.Stderr, "history store error: %v\n", herr)
 		st = nil
 	}
 	ms := initMessage()
@@ -209,6 +209,9 @@ func initialModel(conns *connections.Connections) (*model, error) {
 		layout:      initLayout(),
 	}
 	m.history = history.NewComponent(historyModelAdapter{m}, st)
+	if herr != nil {
+		m.history.Append("", "", "log", false, fmt.Sprintf("history store error: %v", herr))
+	}
 	m.message = message.NewComponent(m, ms)
 	m.help = help.New(navAdapter{m}, &m.ui.width, &m.ui.height, &m.ui.elemPos)
 	m.confirm = confirm.NewDialog(m, m, nil, nil, nil)


### PR DESCRIPTION
## Summary
- Log history store initialization issues and display them in the history panel
- Show persistence errors directly in the history list

## Testing
- `go vet ./...`
- `go test -p 1 ./...` *(fails: directory lock, expected 1 history item got 2)*

------
https://chatgpt.com/codex/tasks/task_e_6896f6ff6520832487412f1ac7ff41cf