### PR TITLE
Prevent duplicate proxy startup with lock

### DIFF
--- a/internal/proxy/lock.go
+++ b/internal/proxy/lock.go
@@ -2,8 +2,17 @@ package proxy
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 )
+
+const lockFileName = "emqutiti-proxy.lock"
+
+// LockPath returns the location of the proxy lock file. All processes should
+// use this path to coordinate proxy startup.
+func LockPath() string {
+	return filepath.Join(os.TempDir(), lockFileName)
+}
 
 // Acquire obtains an exclusive lock on the given file path and returns the
 // locked file. The caller must call Release to free the lock.

--- a/run.go
+++ b/run.go
@@ -147,7 +147,13 @@ func runMain(d *appDeps) {
 		client, err := d.dialProxy(d.proxyAddr)
 		if err != nil {
 			if d.spawnProxy != nil {
-				if spErr := d.spawnProxy(); spErr == nil {
+				if lf, lerr := proxy.Acquire(proxy.LockPath()); lerr == nil {
+					if spErr := d.spawnProxy(); spErr == nil {
+						client, err = d.dialProxy(d.proxyAddr)
+					}
+					_ = proxy.Release(lf)
+				} else {
+					time.Sleep(200 * time.Millisecond)
 					client, err = d.dialProxy(d.proxyAddr)
 				}
 			}


### PR DESCRIPTION
## Summary
- ensure proxy server and clients use shared lock path
- gate proxy spawning on file lock to avoid duplicate instances

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68974bc801ac8324ab15512bf42492e0