### PR TITLE
Wait for proxy startup before releasing lock

### DIFF
--- a/run.go
+++ b/run.go
@@ -149,12 +149,23 @@ func runMain(d *appDeps) {
 			if d.spawnProxy != nil {
 				if lf, lerr := proxy.Acquire(proxy.LockPath()); lerr == nil {
 					if spErr := d.spawnProxy(); spErr == nil {
-						client, err = d.dialProxy(d.proxyAddr)
+						for i := 0; i < 10; i++ {
+							client, err = d.dialProxy(d.proxyAddr)
+							if err == nil {
+								break
+							}
+							time.Sleep(100 * time.Millisecond)
+						}
 					}
 					_ = proxy.Release(lf)
 				} else {
-					time.Sleep(200 * time.Millisecond)
-					client, err = d.dialProxy(d.proxyAddr)
+					for i := 0; i < 10; i++ {
+						time.Sleep(100 * time.Millisecond)
+						client, err = d.dialProxy(d.proxyAddr)
+						if err == nil {
+							break
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- prevent multiple `serve` processes by holding the proxy lock until dialing succeeds

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68975627d76c8324b9b64afec7d141b6