### PR TITLE
Trim proxy startup delay

### DIFF
--- a/internal/proxy/client.go
+++ b/internal/proxy/client.go
@@ -17,7 +17,7 @@ type Client struct {
 // Connect dials the proxy server at the provided address and returns a Client.
 // The connection uses insecure credentials as it is intended for local use.
 func Connect(addr string) (*Client, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
 	if err != nil {

--- a/run.go
+++ b/run.go
@@ -150,7 +150,7 @@ func runMain(d *appDeps) {
 				spErr := d.spawnProxy()
 				_ = proxy.Release(lf)
 				if spErr == nil {
-					for i := 0; i < 10; i++ {
+					for i := 0; i < 5; i++ {
 						client, err = d.dialProxy(d.proxyAddr)
 						if err == nil {
 							break
@@ -159,7 +159,7 @@ func runMain(d *appDeps) {
 					}
 				}
 			} else {
-				for i := 0; i < 10; i++ {
+				for i := 0; i < 5; i++ {
 					time.Sleep(100 * time.Millisecond)
 					client, err = d.dialProxy(d.proxyAddr)
 					if err == nil {


### PR DESCRIPTION
## Summary
- shorten gRPC proxy dial timeout to 200 ms
- reduce proxy connection retries to lower startup latency

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68975b556474832493a0bdecd78d0476