### PR TITLE
Reflow help layout on narrow width

### DIFF
--- a/help_click_test.go
+++ b/help_click_test.go
@@ -12,21 +12,21 @@ import (
 // Test that clicking the help icon opens the help view.
 func TestHelpIconClick(t *testing.T) {
 	m, _ := initialModel(nil)
-	m.ui.width = 40
-	msg := tea.MouseMsg{X: 39, Y: 0, Type: tea.MouseLeft, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress}
+	m.ui.width = helpReflowWidth - 20
+	msg := tea.MouseMsg{X: m.ui.width - 1, Y: 1, Type: tea.MouseLeft, Button: tea.MouseButtonLeft, Action: tea.MouseActionPress}
 	m.Update(msg)
 	if m.CurrentMode() != constants.ModeHelp {
 		t.Fatalf("expected ModeHelp, got %v", m.CurrentMode())
 	}
 }
 
-// Test that the help icon stays on the first line when space is limited.
-func TestHelpIconSticky(t *testing.T) {
+// Test that the help icon reflows to the second line when space is limited.
+func TestHelpIconReflows(t *testing.T) {
 	m, _ := initialModel(nil)
-	m.ui.width = 20
+	m.ui.width = helpReflowWidth - 20
 	view := m.overlayHelp("")
 	lines := strings.Split(view, "\n")
-	if !strings.HasSuffix(lines[0], "?") {
-		t.Fatalf("help icon moved off first line: %q", view)
+	if len(lines) < 2 || strings.Contains(lines[0], "?") || !strings.Contains(lines[1], "?") {
+		t.Fatalf("help icon did not reflow: %q", view)
 	}
 }

--- a/mouse.go
+++ b/mouse.go
@@ -41,7 +41,11 @@ func (m *model) handleMouseScroll(msg tea.MouseMsg) (tea.Cmd, bool) {
 // handleHelpClick switches to help mode when the icon is clicked.
 func (m *model) handleHelpClick(msg tea.MouseMsg) (tea.Cmd, bool) {
 	helpWidth := lipgloss.Width(ui.HelpStyle.Render("?"))
-	if msg.Y == 0 && msg.X >= m.ui.width-helpWidth {
+	helpY := 0
+	if m.ui.width < helpReflowWidth {
+		helpY = 1
+	}
+	if msg.Y == helpY && msg.X >= m.ui.width-helpWidth {
 		return m.SetMode(constants.ModeHelp), true
 	}
 	return nil, false
@@ -57,7 +61,13 @@ func (m *model) handleMouseLeft(msg tea.MouseMsg) tea.Cmd {
 		m.history.HandleClick(msg, m.ui.elemPos[idHistory], m.ui.viewport.YOffset)
 	}
 	helpWidth := lipgloss.Width(ui.HelpStyle.Render("?"))
-	if msg.Y == 1 && msg.X >= m.ui.width-helpWidth+1 {
+	helpY := 0
+	xOffset := 0
+	if m.ui.width < helpReflowWidth {
+		helpY = 1
+		xOffset = 1
+	}
+	if msg.Y == helpY && msg.X >= m.ui.width-helpWidth+xOffset {
 		m.SetMode(constants.ModeHelp)
 	}
 	return cmd

--- a/view_layout_test.go
+++ b/view_layout_test.go
@@ -1,0 +1,24 @@
+package emqutiti
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestOverlayHelpStacksOnNarrowWidth(t *testing.T) {
+	m, _ := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: helpReflowWidth - 10, Height: 20})
+	out := m.overlayHelp("status")
+	lines := strings.Split(out, "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected at least two lines, got %d", len(lines))
+	}
+	if strings.Contains(lines[0], "?") {
+		t.Fatalf("expected first line without help icon: %q", lines[0])
+	}
+	if !strings.Contains(lines[1], "?") || !strings.Contains(lines[1], "status") {
+		t.Fatalf("expected help and status on second line: %q", lines[1])
+	}
+}


### PR DESCRIPTION
## Summary
- Reflow help/info panes vertically when terminal width is below 60 columns
- Adjust mouse handlers to detect help icon on its new row
- Add regression tests for narrow windows and help icon behavior

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68985d41927083248fdce8d152d5fe96