### PR TITLE
Persist importer settings

### DIFF
--- a/importer/file.go
+++ b/importer/file.go
@@ -31,6 +31,9 @@ func (m *Model) updateFile(msg tea.Msg) tea.Cmd {
 		for k := range rows[0] {
 			m.headers = append(m.headers, k)
 			fi := ui.NewTextField(k, "")
+			if v, ok := m.prefs.Mapping[k]; ok {
+				fi.SetValue(v)
+			}
 			fields = append(fields, fi)
 		}
 		if len(fields) > 0 {

--- a/importer/review.go
+++ b/importer/review.go
@@ -15,6 +15,9 @@ func (m *Model) updateReview(msg tea.Msg) tea.Cmd {
 	if km, ok := msg.(tea.KeyMsg); ok {
 		switch km.String() {
 		case constants.KeyP:
+			m.prefs.Mapping = m.mapping()
+			m.prefs.Template = m.tmpl.Value()
+			savePrefs(m.prefs)
 			m.dryRun = false
 			m.index = 0
 			m.published = nil
@@ -23,6 +26,9 @@ func (m *Model) updateReview(msg tea.Msg) tea.Cmd {
 			m.step = stepPublish
 			return tea.Batch(m.progress.SetPercent(0), m.nextPublishCmd())
 		case constants.KeyD:
+			m.prefs.Mapping = m.mapping()
+			m.prefs.Template = m.tmpl.Value()
+			savePrefs(m.prefs)
 			m.dryRun = true
 			m.index = 0
 			m.published = nil


### PR DESCRIPTION
## Summary
- persist column mappings and topic template between importer runs
- load previous mappings and template when starting importer
- verify importer settings round-trip via new tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68985f69b20483248c31eadf2ab80988