### PR TITLE
Expand topic input width and char limit

### DIFF
--- a/topics/init.go
+++ b/topics/init.go
@@ -11,13 +11,13 @@ import (
 func initTopics() state {
 	ti := textinput.New()
 	ti.Placeholder = "Enter Topic"
-	ti.CharLimit = 32
+	ti.CharLimit = 128
 	ti.Prompt = "> "
 	ti.PromptStyle = lipgloss.NewStyle().Foreground(ui.ColGray)
 	ti.PlaceholderStyle = lipgloss.NewStyle().Foreground(ui.ColGray)
 	ti.Cursor.Style = ui.CursorStyle
 	ti.TextStyle = ui.FocusedStyle
-	ti.Width = 0
+	ti.Width = 40
 	topicsList := list.New([]list.Item{}, list.NewDefaultDelegate(), 0, 0)
 	topicsList.DisableQuitKeybindings()
 	topicsList.SetShowTitle(false)

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -27,7 +27,7 @@ func calcConnectionsSize(width, height int) (int, int) {
 
 // calcTopicsInputWidth returns the width for the topics input.
 func calcTopicsInputWidth(width int) int {
-	return width - 7
+	return calcMessageWidth(width)
 }
 
 // calcTraceHeight returns the height for trace views, defaulting if zero.

--- a/update_helpers_test.go
+++ b/update_helpers_test.go
@@ -1,0 +1,14 @@
+package emqutiti
+
+import "testing"
+
+func TestCalcTopicsInputWidth(t *testing.T) {
+	widths := []int{20, 40, 80}
+	for _, w := range widths {
+		want := calcMessageWidth(w)
+		got := calcTopicsInputWidth(w)
+		if got != want {
+			t.Fatalf("width %d: got %d, want %d", w, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- increase topic input char limit and set a default width
- align topics input width calculation with message width
- add tests covering topic input width across terminal sizes

## Testing
- `go vet ./...`
- `go test ./...`
- `make build`


------
https://chatgpt.com/codex/tasks/task_e_689cabe13cb88324977284bc14a05737