### PR TITLE
Add reusable tooltip component with focused styling

### DIFF
--- a/ui/styles.go
+++ b/ui/styles.go
@@ -26,6 +26,10 @@ var (
 	HelpHeader  = lipgloss.NewStyle().Foreground(ColCyan).Bold(true).Underline(true)
 	HelpKey     = lipgloss.NewStyle().Foreground(ColGreen).Width(20)
 
+	// Tooltip styles
+	TooltipStyle   = lipgloss.NewStyle().BorderStyle(lipgloss.RoundedBorder()).BorderForeground(ColGray).Background(ColBlack).Foreground(ColWhite).Padding(0, 1)
+	TooltipFocused = TooltipStyle.BorderForeground(ColPink)
+
 	// Form field styles
 	FormLabel        = lipgloss.NewStyle().Foreground(ColBlue).Bold(true)
 	FormLabelFocused = lipgloss.NewStyle().Foreground(ColPink).Bold(true)

--- a/ui/tooltip.go
+++ b/ui/tooltip.go
@@ -1,0 +1,38 @@
+// Package ui provides shared TUI components and styles.
+package ui
+
+import "github.com/charmbracelet/lipgloss"
+
+// Tooltip displays text inside a bordered box.
+type Tooltip struct {
+	Text  string
+	Width int
+	Style *lipgloss.Style
+}
+
+// View renders the tooltip at the given coordinates using lipgloss.Place.
+func (t Tooltip) View(x, y int) string {
+	style := TooltipStyle
+	if t.Style != nil {
+		style = *t.Style
+	}
+	box := style.Width(t.Width).Render(t.Text)
+	w := lipgloss.Width(box)
+	h := lipgloss.Height(box)
+	return lipgloss.Place(x+w, y+h, lipgloss.Right, lipgloss.Bottom, box)
+}
+
+// RenderTooltip renders content in a tooltip at the specified coordinates.
+// When focused is true, the tooltip uses the focused style.
+func RenderTooltip(content string, x, y int, focused bool) string {
+	style := TooltipStyle
+	if focused {
+		style = TooltipFocused
+	}
+	t := Tooltip{
+		Text:  content,
+		Width: lipgloss.Width(content),
+		Style: &style,
+	}
+	return t.View(x, y)
+}

--- a/ui/tooltip_test.go
+++ b/ui/tooltip_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestTooltipView(t *testing.T) {
+	tt := Tooltip{Text: "hint", Width: 10}
+	out := tt.View(2, 0)
+	t.Logf("\n%s", out)
+	if !strings.Contains(out, "hint") {
+		t.Fatalf("tooltip missing content")
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) == 0 || !strings.HasPrefix(lines[0], "  ") {
+		t.Fatalf("tooltip not positioned correctly: %q", lines)
+	}
+}
+
+func TestRenderTooltipFocused(t *testing.T) {
+	wantFocus := (Tooltip{Text: "hint", Width: lipgloss.Width("hint"), Style: &TooltipFocused}).View(0, 0)
+	gotFocus := RenderTooltip("hint", 0, 0, true)
+	if gotFocus != wantFocus {
+		t.Fatalf("focused tooltip mismatch\nwant:\n%s\n got:\n%s", wantFocus, gotFocus)
+	}
+	wantBlur := (Tooltip{Text: "hint", Width: lipgloss.Width("hint"), Style: &TooltipStyle}).View(0, 0)
+	gotBlur := RenderTooltip("hint", 0, 0, false)
+	if gotBlur != wantBlur {
+		t.Fatalf("blurred tooltip mismatch\nwant:\n%s\n got:\n%s", wantBlur, gotBlur)
+	}
+}

--- a/view_form.go
+++ b/view_form.go
@@ -22,5 +22,7 @@ func (m *model) viewForm() string {
 		formLabel = "Edit Broker"
 	}
 	formView := ui.LegendBox(m.connections.Form.View(), formLabel, m.ui.width/2-2, 0, ui.ColBlue, true, -1)
-	return m.overlayHelp(lipgloss.JoinHorizontal(lipgloss.Top, listView, formView))
+	view := lipgloss.JoinHorizontal(lipgloss.Top, listView, formView)
+	tip := ui.RenderTooltip("Tab to move between fields", m.ui.width/2+1, 0, m.connections.Form.IsFocused(m.connections.Form.Focus))
+	return m.overlayHelp(lipgloss.JoinVertical(lipgloss.Left, view, tip))
 }


### PR DESCRIPTION
## Summary
- add Tooltip widget with RenderTooltip helper for positioning
- style tooltips with focused and blurred themes
- show tooltip usage on form screen

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cacaea30c832488750f57d9cd3a31