### PR TITLE
Fix topic input box border visibility

### DIFF
--- a/ui/box.go
+++ b/ui/box.go
@@ -58,7 +58,7 @@ func legendStyledBox(content, label string, width, height int, color lipgloss.Co
 	for i, l := range lines {
 		l = strings.TrimRightFunc(l, unicode.IsSpace)
 		side := color
-		if i == len(lines)-1 {
+		if i == len(lines)-1 && height > 1 {
 			side = cy
 		}
 		left := lipgloss.NewStyle().Foreground(color).Render(b.Left)

--- a/view_topics.go
+++ b/view_topics.go
@@ -87,7 +87,7 @@ func (m *model) buildTopicBoxes(content string, boxHeight, infoHeight int, scrol
 	topicsBox := ui.LegendBox(content, label, m.ui.width-2, boxHeight+infoHeight, ui.ColBlue, topicsFocused, scroll)
 
 	topicFocused := m.ui.focusOrder[m.ui.focusIndex] == idTopic
-	topicBox := ui.LegendBox(m.topics.Input.View(), "Topic", m.ui.width-2, 0, ui.ColBlue, topicFocused, -1)
+	topicBox := ui.LegendBox(m.topics.Input.View(), "Topic", m.ui.width-2, 1, ui.ColBlue, topicFocused, -1)
 	return topicsBox, topicBox
 }
 


### PR DESCRIPTION
## Summary
- keep topic input box height fixed to one line
- ensure single-line boxes render right border in chosen color

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cc4dd352083249b2949df1e88c5be