### PR TITLE
Fix topic input box border visibility

### DIFF
--- a/ui/box.go
+++ b/ui/box.go
@@ -58,7 +58,7 @@ func legendStyledBox(content, label string, width, height int, color lipgloss.Co
 	for i, l := range lines {
 		l = strings.TrimRightFunc(l, unicode.IsSpace)
 		side := color
-		if i == len(lines)-1 {
+		if i == len(lines)-1 && height > 1 {
 			side = cy
 		}
 		left := lipgloss.NewStyle().Foreground(color).Render(b.Left)

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -26,8 +26,14 @@ func calcConnectionsSize(width, height int) (int, int) {
 }
 
 // calcTopicsInputWidth returns the width for the topics input.
+// It subtracts space for the prompt and cursor so the surrounding box
+// stays on a single line.
 func calcTopicsInputWidth(width int) int {
-	return calcMessageWidth(width)
+	w := calcMessageWidth(width) - 3
+	if w < 0 {
+		return 0
+	}
+	return w
 }
 
 // calcTraceHeight returns the height for trace views, defaulting if zero.

--- a/update_helpers_test.go
+++ b/update_helpers_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestCalcTopicsInputWidth(t *testing.T) {
 	widths := []int{20, 40, 80}
 	for _, w := range widths {
-		want := calcMessageWidth(w)
+		want := calcMessageWidth(w) - 3
 		got := calcTopicsInputWidth(w)
 		if got != want {
 			t.Fatalf("width %d: got %d, want %d", w, got, want)

--- a/view_topics.go
+++ b/view_topics.go
@@ -87,7 +87,7 @@ func (m *model) buildTopicBoxes(content string, boxHeight, infoHeight int, scrol
 	topicsBox := ui.LegendBox(content, label, m.ui.width-2, boxHeight+infoHeight, ui.ColBlue, topicsFocused, scroll)
 
 	topicFocused := m.ui.focusOrder[m.ui.focusIndex] == idTopic
-	topicBox := ui.LegendBox(m.topics.Input.View(), "Topic", m.ui.width-2, 0, ui.ColBlue, topicFocused, -1)
+	topicBox := ui.LegendBox(m.topics.Input.View(), "Topic", m.ui.width-2, 1, ui.ColBlue, topicFocused, -1)
 	return topicsBox, topicBox
 }
 


### PR DESCRIPTION
## Summary
- keep topic input box height fixed to one line
- ensure single-line boxes render right border in chosen color
- subtract prompt and cursor width from topic input so the box stays within bounds

## Testing
- `go vet ./...` *(fails: process hung)*
- `go test ./...` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_689cc4dd352083249b2949df1e88c5be