### PR TITLE
ui: retain trailing space in LegendBox

### DIFF
--- a/ui/box.go
+++ b/ui/box.go
@@ -56,7 +56,11 @@ func legendStyledBox(content, label string, width, height int, color lipgloss.Co
 	}
 
 	for i, l := range lines {
-		l = strings.TrimRightFunc(l, unicode.IsSpace)
+		trimmed := strings.TrimRightFunc(l, unicode.IsSpace)
+		if len(l) > len(trimmed) {
+			trimmed += " "
+		}
+		l = trimmed
 		side := color
 		if i == len(lines)-1 && height > 1 {
 			side = cy

--- a/ui/layout_test.go
+++ b/ui/layout_test.go
@@ -69,3 +69,26 @@ func TestLegendBoxLayouts(t *testing.T) {
 		})
 	}
 }
+
+func TestLegendBoxTextFieldFocused(t *testing.T) {
+	tf := NewTextField("", "")
+	tf.Model.Width = 5
+	tf.Focus()
+	view := tf.View()
+	width := lipgloss.Width(view) + 2
+	box := LegendBox(view, "Lbl", width, 0, ColGreen, true, -1)
+	lines := strings.Split(box, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("box height=%d want=3", len(lines))
+	}
+	content := lines[1]
+	b := lipgloss.RoundedBorder()
+	left := lipgloss.NewStyle().Foreground(ColGreen).Render(b.Left)
+	if !strings.HasPrefix(content, left) {
+		t.Fatalf("missing left border: %q", content)
+	}
+	right := lipgloss.NewStyle().Foreground(ColGreen).Render(b.Right)
+	if !strings.HasSuffix(content, right) {
+		t.Fatalf("missing right border: %q", content)
+	}
+}


### PR DESCRIPTION
## Summary
- keep a trailing space when trimming LegendBox lines so cursors stay visible
- add focused test for TextField wrapped in LegendBox

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cdd2b70a88324b0ebfd3c7ea6114a