### PR TITLE
refactor: centralize flag parsing

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+type AppConfig struct {
+	ImportFile  string
+	ProfileName string
+	TraceKey    string
+	TraceTopics string
+	TraceStart  string
+	TraceEnd    string
+}
+
+func ParseFlags() AppConfig {
+	var cfg AppConfig
+	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	fs.StringVar(&cfg.ImportFile, "import", "", "Launch import wizard with optional file path")
+	fs.StringVar(&cfg.ImportFile, "i", "", "(shorthand)")
+	fs.StringVar(&cfg.ProfileName, "profile", "", "Connection profile name to use")
+	fs.StringVar(&cfg.ProfileName, "p", "", "(shorthand)")
+	fs.StringVar(&cfg.TraceKey, "trace", "", "Trace key name to store messages")
+	fs.StringVar(&cfg.TraceTopics, "topics", "", "Comma-separated topics to trace")
+	fs.StringVar(&cfg.TraceStart, "start", "", "Optional RFC3339 trace start time")
+	fs.StringVar(&cfg.TraceEnd, "end", "", "Optional RFC3339 trace end time")
+	fs.Usage = func() {
+		w := fs.Output()
+		fmt.Fprintf(w, "Usage: %s [flags]\n\n", os.Args[0])
+		fmt.Fprintln(w, "General:")
+		fmt.Fprintln(w, "  -i, --import FILE     Launch import wizard with optional file path (e.g., -i data.csv)")
+		fmt.Fprintln(w, "  -p, --profile NAME    Connection profile name to use (e.g., -p local)")
+		fmt.Fprintln(w, "")
+		fmt.Fprintln(w, "Trace:")
+		fmt.Fprintln(w, "      --trace KEY       Trace key name to store messages (e.g., --trace run1)")
+		fmt.Fprintln(w, "      --topics LIST     Comma-separated topics to trace (e.g., --topics \"sensors/#\")")
+		fmt.Fprintln(w, "      --start TIME      Optional RFC3339 trace start time (e.g., --start \"2025-08-05T11:47:00Z\")")
+		fmt.Fprintln(w, "      --end TIME        Optional RFC3339 trace end time (e.g., --end \"2025-08-05T11:49:00Z\")")
+	}
+	_ = fs.Parse(os.Args[1:])
+	return cfg
+}

--- a/cmd/emqutiti/main.go
+++ b/cmd/emqutiti/main.go
@@ -1,7 +1,10 @@
 package main
 
-import "github.com/marang/emqutiti"
+import (
+	app "github.com/marang/emqutiti"
+	cfg "github.com/marang/emqutiti/cmd"
+)
 
 func main() {
-	emqutiti.Main()
+	app.Main(cfg.ParseFlags())
 }


### PR DESCRIPTION
## Summary
- add AppConfig struct and flag parser in cmd/config.go
- pass AppConfig to Main and runMain to remove reliance on globals
- update entry point and tests to build and use AppConfig directly

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ce9f7fab4832491c13b13bef6545e