### PR TITLE
refactor focus cycling into helper

### DIFF
--- a/update_helpers_test.go
+++ b/update_helpers_test.go
@@ -12,3 +12,24 @@ func TestCalcTopicsInputWidth(t *testing.T) {
 		}
 	}
 }
+
+func TestCycleFocusNext(t *testing.T) {
+	m, _ := initialModel(nil)
+	if _, ok := m.cycleFocus(focusNext); !ok {
+		t.Fatalf("cycleFocus next should return true")
+	}
+	if m.focus.Index() != 1 {
+		t.Fatalf("focus index got %d, want 1", m.focus.Index())
+	}
+}
+
+func TestCycleFocusPrevWraps(t *testing.T) {
+	m, _ := initialModel(nil)
+	if _, ok := m.cycleFocus(focusPrev); !ok {
+		t.Fatalf("cycleFocus prev should return true")
+	}
+	want := len(m.ui.focusOrder) - 1
+	if m.focus.Index() != want {
+		t.Fatalf("focus index got %d, want %d", m.focus.Index(), want)
+	}
+}


### PR DESCRIPTION
## Summary
- add constants and cycleFocus helper to manage focus traversal
- replace KeyTab/KeyShiftTab handling with cycleFocus calls
- test cycleFocus forward and backward behavior

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cef567b108324989d628a99afd403