### PR TITLE
Refactor help overlay layout helpers

### DIFF
--- a/view_layout_test.go
+++ b/view_layout_test.go
@@ -22,3 +22,16 @@ func TestOverlayHelpStacksOnNarrowWidth(t *testing.T) {
 		t.Fatalf("expected help and status on second line: %q", lines[1])
 	}
 }
+
+func TestOverlayHelpInlineOnWideWidth(t *testing.T) {
+	m, _ := initialModel(nil)
+	m.Update(tea.WindowSizeMsg{Width: helpReflowWidth + 10, Height: 20})
+	out := m.overlayHelp("status")
+	lines := strings.Split(out, "\n")
+	if !strings.Contains(lines[0], "?") || !strings.Contains(lines[0], "Switch views") {
+		t.Fatalf("expected help and info on first line: %q", lines[0])
+	}
+	if len(lines) < 2 || strings.Contains(lines[1], "?") || !strings.Contains(lines[1], "status") {
+		t.Fatalf("unexpected second line: %v", lines)
+	}
+}


### PR DESCRIPTION
## Summary
- extract width calculation and rendering helpers for help overlay
- test overlay rendering for narrow and wide terminals

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cef6fd0848324b08eb0cea5bac930