### PR TITLE
refactor model init into submodules

### DIFF
--- a/model_init_connections.go
+++ b/model_init_connections.go
@@ -1,0 +1,71 @@
+package emqutiti
+
+import (
+	"github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/constants"
+	"github.com/marang/emqutiti/focus"
+)
+
+func initConnections(conns *connections.Connections) (connections.State, error) {
+	var connModel connections.Connections
+	var loadErr error
+	if conns != nil {
+		connModel = *conns
+	} else {
+		connModel = connections.NewConnectionsModel()
+		if err := connModel.LoadProfiles(""); err != nil {
+			loadErr = err
+		}
+	}
+	connModel.ConnectionsList.SetShowStatusBar(false)
+	for _, p := range connModel.Profiles {
+		if _, ok := connModel.Statuses[p.Name]; !ok {
+			connModel.Statuses[p.Name] = "disconnected"
+		}
+	}
+	statusChan := make(chan string, 10)
+	saved := connections.LoadState()
+	cs := connections.State{
+		Connection:  "",
+		Active:      "",
+		Manager:     connModel,
+		Form:        nil,
+		DeleteIndex: 0,
+		StatusChan:  statusChan,
+		Saved:       saved,
+	}
+	cs.RefreshConnectionItems()
+	return cs, loadErr
+}
+
+// initComponents registers focusable elements and mode components.
+func initComponents(m *model, order []string, connComp Component) {
+	providers := []focus.FocusableSet{m, m.topics, m.message, m.payloads, m.traces, m.help}
+	m.focusables = map[string]focus.Focusable{}
+	for _, p := range providers {
+		for id, f := range p.Focusables() {
+			m.focusables[id] = f
+		}
+	}
+	fitems := make([]focus.Focusable, len(order))
+	for i, id := range order {
+		fitems[i] = m.focusables[id]
+	}
+	m.focus = focus.NewFocusMap(fitems)
+	m.components = map[constants.AppMode]Component{
+		constants.ModeClient:         component{update: m.updateClient, view: m.viewClient},
+		constants.ModeConnections:    connComp,
+		constants.ModeEditConnection: component{update: m.updateConnectionForm, view: m.viewForm},
+		constants.ModeConfirmDelete:  m.confirm,
+		constants.ModeTopics:         m.topics,
+		constants.ModePayloads:       m.payloads,
+		constants.ModeTracer:         m.traces,
+		constants.ModeEditTrace:      component{update: m.traces.UpdateForm, view: m.traces.ViewForm},
+		constants.ModeViewTrace:      component{update: m.traces.UpdateView, view: m.traces.ViewMessages},
+		constants.ModeTraceFilter:    component{update: m.traces.UpdateFilter, view: m.traces.ViewFilter},
+		constants.ModeHistoryFilter:  component{update: m.history.UpdateFilter, view: m.history.ViewFilter},
+		constants.ModeHistoryDetail:  component{update: m.history.UpdateDetail, view: m.history.ViewDetail},
+		constants.ModeHelp:           m.help,
+		constants.ModeLogs:           m.logs,
+	}
+}

--- a/model_init_importer.go
+++ b/model_init_importer.go
@@ -1,0 +1,53 @@
+package emqutiti
+
+import (
+	"fmt"
+
+	"github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/constants"
+	"github.com/marang/emqutiti/importer"
+)
+
+// initImporter bootstraps the importer for a selected profile.
+func initImporter(m *model) error {
+	if importFile == "" {
+		return nil
+	}
+	var p *connections.Profile
+	if profileName != "" {
+		for i := range m.connections.Manager.Profiles {
+			if m.connections.Manager.Profiles[i].Name == profileName {
+				p = &m.connections.Manager.Profiles[i]
+				break
+			}
+		}
+	} else if m.connections.Manager.DefaultProfileName != "" {
+		for i := range m.connections.Manager.Profiles {
+			if m.connections.Manager.Profiles[i].Name == m.connections.Manager.DefaultProfileName {
+				p = &m.connections.Manager.Profiles[i]
+				break
+			}
+		}
+	}
+	if p == nil && len(m.connections.Manager.Profiles) > 0 {
+		p = &m.connections.Manager.Profiles[0]
+	}
+	if p == nil {
+		return nil
+	}
+	cfg := *p
+	if cfg.FromEnv {
+		connections.ApplyEnvVars(&cfg)
+	}
+	connections.ApplyDefaultPassword(&cfg)
+	client, err := NewMQTTClient(cfg, nil)
+	if err != nil {
+		return fmt.Errorf("connect error: %w", err)
+	}
+	m.mqttClient = client
+	m.connections.Active = cfg.Name
+	m.importer = importer.New(client, importFile)
+	m.components[constants.ModeImporter] = m.importer
+	m.SetMode(constants.ModeImporter)
+	return nil
+}

--- a/model_init_ui.go
+++ b/model_init_ui.go
@@ -1,0 +1,33 @@
+package emqutiti
+
+import (
+	"github.com/charmbracelet/bubbles/viewport"
+	"github.com/marang/emqutiti/constants"
+)
+
+func initUI(order []string) uiState {
+	vp := viewport.New(0, 0)
+	fm := make(map[string]int, len(order))
+	for i, id := range order {
+		fm[id] = i
+	}
+	return uiState{
+		focusIndex: 0,
+		modeStack:  []constants.AppMode{constants.ModeClient},
+		width:      0,
+		height:     0,
+		viewport:   vp,
+		elemPos:    map[string]int{},
+		focusOrder: order,
+		focusMap:   fm,
+	}
+}
+
+func initLayout() layoutConfig {
+	return layoutConfig{
+		message: boxConfig{height: 6},
+		history: boxConfig{height: 10},
+		topics:  boxConfig{height: 1},
+		trace:   boxConfig{height: 10},
+	}
+}


### PR DESCRIPTION
## Summary
- move connection and component setup into `model_init_connections.go`
- extract UI and layout initialization to `model_init_ui.go`
- split importer bootstrapping into `model_init_importer.go`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cf6f5d9f48324a3c53ee529a552d0