### PR TITLE
Add layout manager and refactor size calculations

### DIFF
--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -55,18 +55,18 @@ func (m *model) handleResizeUpKey() tea.Cmd {
 	id := m.ui.focusOrder[m.ui.focusIndex]
 	switch id {
 	case idMessage:
-		if m.layout.message.height > 1 {
-			m.layout.message.height--
-			m.message.Input().SetHeight(m.layout.message.height)
+		if m.layout.Message.Height > 1 {
+			m.layout.Message.Height--
+			m.message.Input().SetHeight(m.layout.Message.Height)
 		}
 	case idHistory:
-		if m.layout.history.height > 1 {
-			m.layout.history.height--
-			m.history.List().SetSize(m.ui.width-4, m.layout.history.height)
+		if m.layout.History.Height > 1 {
+			m.layout.History.Height--
+			m.history.List().SetSize(m.ui.width-4, m.layout.History.Height)
 		}
 	case idTopics:
-		if m.layout.topics.height > 1 {
-			m.layout.topics.height--
+		if m.layout.Topics.Height > 1 {
+			m.layout.Topics.Height--
 		}
 	}
 	return nil
@@ -77,13 +77,13 @@ func (m *model) handleResizeDownKey() tea.Cmd {
 	id := m.ui.focusOrder[m.ui.focusIndex]
 	switch id {
 	case idMessage:
-		m.layout.message.height++
-		m.message.Input().SetHeight(m.layout.message.height)
+		m.layout.Message.Height++
+		m.message.Input().SetHeight(m.layout.Message.Height)
 	case idHistory:
-		m.layout.history.height++
-		m.history.List().SetSize(m.ui.width-4, m.layout.history.height)
+		m.layout.History.Height++
+		m.history.List().SetSize(m.ui.width-4, m.layout.History.Height)
 	case idTopics:
-		m.layout.topics.height++
+		m.layout.Topics.Height++
 	}
 	return nil
 }

--- a/layout/manager.go
+++ b/layout/manager.go
@@ -1,0 +1,71 @@
+package layout
+
+// Box represents a UI box with a height.
+type Box struct {
+	Height int
+}
+
+// Manager computes layout sizes and stores user-configurable heights.
+type Manager struct {
+	Message Box
+	History Box
+	Topics  Box
+	Trace   Box
+}
+
+// MessageWidth returns the width for message inputs and lists.
+func (m Manager) MessageWidth(width int) int {
+	return width - 4
+}
+
+// TopicsInputWidth returns the width for the topics input. It subtracts space
+// for the prompt and cursor so the surrounding box stays on a single line.
+func (m Manager) TopicsInputWidth(width int) int {
+	w := m.MessageWidth(width) - 3
+	if w < 0 {
+		return 0
+	}
+	return w
+}
+
+// ConnectionsSize returns the width and height for the connections list.
+func (m Manager) ConnectionsSize(width, height int) (int, int) {
+	return m.MessageWidth(width), height - 6
+}
+
+// HistorySize returns the width and height for the history list. It defaults
+// the height when the current value is zero.
+func (m *Manager) HistorySize(width, height int) (int, int) {
+	if m.History.Height == 0 {
+		m.History.Height = (height-1)/3 + 10
+	}
+	return m.MessageWidth(width), m.History.Height
+}
+
+// TraceHeight returns the height for trace views, defaulting if zero.
+func (m *Manager) TraceHeight(height int) int {
+	if m.Trace.Height == 0 {
+		m.Trace.Height = height - 6
+	}
+	return m.Trace.Height
+}
+
+// TraceListSize returns size for trace lists.
+func (m Manager) TraceListSize(width, height int) (int, int) {
+	return m.MessageWidth(width), height - 4
+}
+
+// TopicsListSize returns size for the topics list.
+func (m Manager) TopicsListSize(width, height int) (int, int) {
+	return width/2 - 4, height - 4
+}
+
+// DetailSize returns size for the history detail view.
+func (m Manager) DetailSize(width, height int) (int, int) {
+	return m.MessageWidth(width), height - 4
+}
+
+// ViewportHeight returns the viewport height, reserving two lines for headers.
+func (m Manager) ViewportHeight(height int) int {
+	return height - 2
+}

--- a/layout/manager_test.go
+++ b/layout/manager_test.go
@@ -1,0 +1,41 @@
+package layout
+
+import "testing"
+
+func TestTopicsInputWidth(t *testing.T) {
+	m := Manager{}
+	widths := []int{20, 40, 80}
+	for _, w := range widths {
+		want := w - 7
+		got := m.TopicsInputWidth(w)
+		if got != want {
+			t.Fatalf("width %d: got %d, want %d", w, got, want)
+		}
+	}
+}
+
+func TestHistorySizeDefault(t *testing.T) {
+	m := Manager{}
+	w, h := m.HistorySize(60, 30)
+	if w != 56 {
+		t.Fatalf("width got %d, want 56", w)
+	}
+	wantH := (30-1)/3 + 10
+	if h != wantH {
+		t.Fatalf("height got %d, want %d", h, wantH)
+	}
+	if m.History.Height != wantH {
+		t.Fatalf("stored height %d, want %d", m.History.Height, wantH)
+	}
+}
+
+func TestTraceHeightDefault(t *testing.T) {
+	m := Manager{}
+	h := m.TraceHeight(40)
+	if h != 34 {
+		t.Fatalf("height got %d, want 34", h)
+	}
+	if m.Trace.Height != 34 {
+		t.Fatalf("stored height %d, want 34", m.Trace.Height)
+	}
+}

--- a/model.go
+++ b/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/history"
 	"github.com/marang/emqutiti/importer"
+	"github.com/marang/emqutiti/layout"
 	"github.com/marang/emqutiti/logs"
 	"github.com/marang/emqutiti/message"
 	"github.com/marang/emqutiti/payloads"
@@ -77,17 +78,6 @@ func (c component) Blur() {
 	}
 }
 
-type boxConfig struct {
-	height int
-}
-
-type layoutConfig struct {
-	message boxConfig
-	history boxConfig
-	topics  boxConfig
-	trace   boxConfig
-}
-
 // uiState groups general UI information such as current focus and layout.
 type uiState struct {
 	focusIndex int                 // index of the currently focused element
@@ -117,7 +107,7 @@ type model struct {
 
 	confirm *confirm.Dialog
 
-	layout layoutConfig
+	layout layout.Manager
 
 	// components maps each application mode to its corresponding component
 	// implementation. These components handle mode-specific update and view

--- a/model_helpers.go
+++ b/model_helpers.go
@@ -134,7 +134,7 @@ func (m *model) SetPreviousMode() tea.Cmd { return m.SetMode(m.PreviousMode()) }
 func (m *model) Width() int { return m.ui.width }
 
 // MessageHeight returns the configured message box height.
-func (m *model) MessageHeight() int { return m.layout.message.height }
+func (m *model) MessageHeight() int { return m.layout.Message.Height }
 
 // Height returns the current UI height.
 func (m *model) Height() int { return m.ui.height }

--- a/model_init.go
+++ b/model_init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/marang/emqutiti/focus"
 	"github.com/marang/emqutiti/help"
 	"github.com/marang/emqutiti/importer"
+	"github.com/marang/emqutiti/layout"
 	"github.com/marang/emqutiti/logs"
 	"github.com/marang/emqutiti/message"
 	"github.com/marang/emqutiti/topics"
@@ -105,12 +106,12 @@ func initUI(order []string) uiState {
 	}
 }
 
-func initLayout() layoutConfig {
-	return layoutConfig{
-		message: boxConfig{height: 6},
-		history: boxConfig{height: 10},
-		topics:  boxConfig{height: 1},
-		trace:   boxConfig{height: 10},
+func initLayout() layout.Manager {
+	return layout.Manager{
+		Message: layout.Box{Height: 6},
+		History: layout.Box{Height: 10},
+		Topics:  layout.Box{Height: 1},
+		Trace:   layout.Box{Height: 10},
 	}
 }
 

--- a/traces_api_impl.go
+++ b/traces_api_impl.go
@@ -34,9 +34,9 @@ func (m *model) LogHistory(topic, payload, kind string, retained bool, text stri
 	m.history.Append(topic, payload, kind, retained, text)
 }
 
-func (m *model) TraceHeight() int { return m.layout.trace.height }
+func (m *model) TraceHeight() int { return m.layout.Trace.Height }
 
-func (m *model) SetTraceHeight(h int) { m.layout.trace.height = h }
+func (m *model) SetTraceHeight(h int) { m.layout.Trace.Height = h }
 
 func (m *model) NewClient(p connections.Profile) (traces.Client, error) {
 	return NewMQTTClient(p, nil)

--- a/update_client_helpers_test.go
+++ b/update_client_helpers_test.go
@@ -55,7 +55,7 @@ func TestHandleMouseScrollTopics(t *testing.T) {
 	m.Update(tea.WindowSizeMsg{Width: 40, Height: 20})
 	setupManyTopics(m, 10)
 	rowH := lipgloss.Height(ui.Chip.Render("t"))
-	m.layout.topics.height = rowH
+	m.layout.Topics.Height = rowH
 	m.viewClient()
 	m.SetFocus(idTopics)
 	_, handled := m.handleMouseScroll(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
@@ -72,7 +72,7 @@ func setupManyTopics(m *model, n int) {
 		title := fmt.Sprintf("topic-%d", i)
 		m.topics.Items = append(m.topics.Items, topics.Item{Name: title, Subscribed: true})
 	}
-	m.layout.topics.height = n
+	m.layout.Topics.Height = n
 }
 
 func TestHandleHistorySelectionShift(t *testing.T) {

--- a/update_helpers.go
+++ b/update_helpers.go
@@ -11,93 +11,34 @@ const (
 	focusPrev = -1
 )
 
-// calcHistorySize returns the width and height for the history list.
-// It defaults the height when the current value is zero.
-func calcHistorySize(width, height, currentHeight int) (int, int) {
-	if currentHeight == 0 {
-		currentHeight = (height-1)/3 + 10
-	}
-	return calcMessageWidth(width), currentHeight
-}
-
-// calcMessageWidth returns the width for message inputs and lists.
-func calcMessageWidth(width int) int {
-	return width - 4
-}
-
-// calcConnectionsSize returns the width and height for the connections list.
-func calcConnectionsSize(width, height int) (int, int) {
-	return calcMessageWidth(width), height - 6
-}
-
-// calcTopicsInputWidth returns the width for the topics input.
-// It subtracts space for the prompt and cursor so the surrounding box
-// stays on a single line.
-func calcTopicsInputWidth(width int) int {
-	w := calcMessageWidth(width) - 3
-	if w < 0 {
-		return 0
-	}
-	return w
-}
-
-// calcTraceHeight returns the height for trace views, defaulting if zero.
-func calcTraceHeight(height, currentHeight int) int {
-	if currentHeight == 0 {
-		return height - 6
-	}
-	return currentHeight
-}
-
-// calcTraceListSize returns size for trace lists.
-func calcTraceListSize(width, height int) (int, int) {
-	return calcMessageWidth(width), height - 4
-}
-
-// calcTopicsListSize returns size for the topics list.
-func calcTopicsListSize(width, height int) (int, int) {
-	return width/2 - 4, height - 4
-}
-
-// calcDetailSize returns size for the history detail view.
-func calcDetailSize(width, height int) (int, int) {
-	return calcMessageWidth(width), height - 4
-}
-
-// calcViewportHeight returns the viewport height, reserving two lines for headers.
-func calcViewportHeight(height int) int {
-	return height - 2
-}
-
 // handleWindowSize adjusts the layout when the terminal is resized.
 func (m *model) handleWindowSize(msg tea.WindowSizeMsg) tea.Cmd {
 	m.ui.width = msg.Width
 	m.ui.height = msg.Height
-	cw, ch := calcConnectionsSize(msg.Width, msg.Height)
+	cw, ch := m.layout.ConnectionsSize(msg.Width, msg.Height)
 	m.connections.Manager.ConnectionsList.SetSize(cw, ch)
 	// textinput.View() renders the prompt and cursor in addition
 	// to the configured width. Reduce the width slightly so the
 	// surrounding box stays within the terminal boundaries.
-	m.topics.Input.Width = calcTopicsInputWidth(msg.Width)
-	m.message.Input().SetWidth(calcMessageWidth(msg.Width))
-	m.message.Input().SetHeight(m.layout.message.height)
-	hw, hh := calcHistorySize(msg.Width, msg.Height, m.layout.history.height)
-	m.layout.history.height = hh
+	m.topics.Input.Width = m.layout.TopicsInputWidth(msg.Width)
+	m.message.Input().SetWidth(m.layout.MessageWidth(msg.Width))
+	m.message.Input().SetHeight(m.layout.Message.Height)
+	hw, hh := m.layout.HistorySize(msg.Width, msg.Height)
 	m.history.List().SetSize(hw, hh)
-	m.layout.trace.height = calcTraceHeight(msg.Height, m.layout.trace.height)
-	m.traces.ViewList().SetSize(calcMessageWidth(msg.Width), m.layout.trace.height)
-	tw, th := calcTraceListSize(msg.Width, msg.Height)
-	m.traces.List().SetSize(tw, th)
-	lw, lh := calcTopicsListSize(msg.Width, msg.Height)
+	th := m.layout.TraceHeight(msg.Height)
+	m.traces.ViewList().SetSize(m.layout.MessageWidth(msg.Width), th)
+	tw, tlh := m.layout.TraceListSize(msg.Width, msg.Height)
+	m.traces.List().SetSize(tw, tlh)
+	lw, lh := m.layout.TopicsListSize(msg.Width, msg.Height)
 	m.topics.List().SetSize(lw, lh)
 	m.help.SetSize(msg.Width, msg.Height)
 	m.logs.SetSize(msg.Width, msg.Height)
-	dw, dh := calcDetailSize(msg.Width, msg.Height)
+	dw, dh := m.layout.DetailSize(msg.Width, msg.Height)
 	m.history.Detail().Width = dw
 	m.history.Detail().Height = dh
 	m.ui.viewport.Width = msg.Width
 	// Reserve two lines for the info header at the top of the view.
-	m.ui.viewport.Height = calcViewportHeight(msg.Height)
+	m.ui.viewport.Height = m.layout.ViewportHeight(msg.Height)
 	return nil
 }
 

--- a/update_helpers_test.go
+++ b/update_helpers_test.go
@@ -2,17 +2,6 @@ package emqutiti
 
 import "testing"
 
-func TestCalcTopicsInputWidth(t *testing.T) {
-	widths := []int{20, 40, 80}
-	for _, w := range widths {
-		want := calcMessageWidth(w) - 3
-		got := calcTopicsInputWidth(w)
-		if got != want {
-			t.Fatalf("width %d: got %d, want %d", w, got, want)
-		}
-	}
-}
-
 func TestCycleFocusNext(t *testing.T) {
 	m, _ := initialModel(nil)
 	if _, ok := m.cycleFocus(focusNext); !ok {

--- a/view_form.go
+++ b/view_form.go
@@ -14,7 +14,7 @@ func (m *model) viewForm() string {
 	if m.connections.Form == nil {
 		return ""
 	}
-	cw, ch := calcConnectionsSize(m.ui.width/2, m.ui.height)
+	cw, ch := m.layout.ConnectionsSize(m.ui.width/2, m.ui.height)
 	m.connections.Manager.ConnectionsList.SetSize(cw, ch)
 	listView := ui.LegendBox(m.connections.Manager.ConnectionsList.View(), "Brokers", m.ui.width/2-2, 0, ui.ColBlue, false, -1)
 	formLabel := "Add Broker"

--- a/view_history.go
+++ b/view_history.go
@@ -29,7 +29,7 @@ func (m *model) renderHistorySection() string {
 	if m.history.FilterQuery() != "" && shown != total {
 		histLabel = fmt.Sprintf("History (%d/%d messages \u2013 Ctrl+C copy)", shown, total)
 	}
-	listHeight := m.layout.history.height
+	listHeight := m.layout.History.Height
 	if m.history.FilterQuery() != "" && listHeight > 0 {
 		listHeight--
 	}
@@ -42,5 +42,5 @@ func (m *model) renderHistorySection() string {
 		histContent = fmt.Sprintf("%s\n%s", filterLine, histContent)
 	}
 	historyFocused := m.ui.focusOrder[m.ui.focusIndex] == idHistory
-	return ui.LegendBox(histContent, histLabel, m.ui.width-2, m.layout.history.height, ui.ColGreen, historyFocused, histSP)
+	return ui.LegendBox(histContent, histLabel, m.ui.width-2, m.layout.History.Height, ui.ColGreen, historyFocused, histSP)
 }

--- a/view_topics.go
+++ b/view_topics.go
@@ -69,7 +69,7 @@ func renderTopicChips(items []topics.Item, selected, width int) []string {
 func (m *model) layoutTopicViewport(chips []string) (string, []topics.ChipBound, int, int, float64) {
 	chipRows, bounds := topics.LayoutChips(chips, m.ui.width-4)
 	rowH := lipgloss.Height(ui.Chip.Render("test"))
-	maxRows := m.layout.topics.height
+	maxRows := m.layout.Topics.Height
 	if maxRows <= 0 {
 		maxRows = 1
 	}


### PR DESCRIPTION
## Summary
- centralize layout size calculations in new `layout.Manager`
- refactor window resize logic to use manager
- add tests for layout computations

## Testing
- `go vet ./layout`
- `go test ./layout`
- `go vet ./...` *(fails: timed out)*
- `go test ./...` *(fails: timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689cf7041fd083248beb89791fcfa85c