### PR TITLE
Add context-aware trace timeout

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 )
 
 type AppConfig struct {
@@ -13,6 +14,7 @@ type AppConfig struct {
 	TraceTopics string
 	TraceStart  string
 	TraceEnd    string
+	Timeout     time.Duration
 }
 
 func ParseFlags() AppConfig {
@@ -26,6 +28,7 @@ func ParseFlags() AppConfig {
 	fs.StringVar(&cfg.TraceTopics, "topics", "", "Comma-separated topics to trace")
 	fs.StringVar(&cfg.TraceStart, "start", "", "Optional RFC3339 trace start time")
 	fs.StringVar(&cfg.TraceEnd, "end", "", "Optional RFC3339 trace end time")
+	fs.DurationVar(&cfg.Timeout, "timeout", 0, "Optional overall runtime limit (e.g., 30s)")
 	fs.Usage = func() {
 		w := fs.Output()
 		fmt.Fprintf(w, "Usage: %s [flags]\n\n", os.Args[0])

--- a/traces/headless.go
+++ b/traces/headless.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	connections "github.com/marang/emqutiti/connections"
@@ -86,7 +87,7 @@ func (m *mqttClient) Disconnect() {
 }
 
 // Run executes the tracer headlessly using configuration from config.toml.
-func Run(key, topics, profileName, startStr, endStr string) error {
+func Run(ctx context.Context, key, topics, profileName, startStr, endStr string) error {
 	if key == "" || topics == "" {
 		return fmt.Errorf("-trace and -topics are required")
 	}
@@ -138,6 +139,9 @@ func Run(key, topics, profileName, startStr, endStr string) error {
 		select {
 		case <-sig:
 			tr.Stop()
+		case <-ctx.Done():
+			tr.Stop()
+			return ctx.Err()
 		case <-time.After(500 * time.Millisecond):
 		}
 	}


### PR DESCRIPTION
## Summary
- allow `runTrace` and `traces.Run` to accept a `context.Context`
- add `--timeout` flag to cancel long-running traces
- test trace cancellation with short timeout

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cf72e55808324a03f377ab0b6636e