### PR TITLE
refactor: centralize component key handling

### DIFF
--- a/connections/component_test.go
+++ b/connections/component_test.go
@@ -1,0 +1,56 @@
+package connections
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/marang/emqutiti/constants"
+)
+
+type testNav struct{ mode constants.AppMode }
+
+func (t *testNav) SetMode(m constants.AppMode) tea.Cmd { t.mode = m; return nil }
+func (t *testNav) Width() int                          { return 80 }
+func (t *testNav) Height() int                         { return 24 }
+
+type testAPI struct {
+	began bool
+	mgr   *Connections
+}
+
+func (t *testAPI) Manager() *Connections             { return t.mgr }
+func (t *testAPI) ListenStatus() tea.Cmd             { return nil }
+func (t *testAPI) SendStatus(string)                 {}
+func (t *testAPI) FlushStatus()                      {}
+func (t *testAPI) RefreshConnectionItems()           {}
+func (t *testAPI) SubscribeActiveTopics()            {}
+func (t *testAPI) ConnectionMessage() string         { return "" }
+func (t *testAPI) SetConnectionMessage(string)       {}
+func (t *testAPI) Active() string                    { return "" }
+func (t *testAPI) BeginAdd()                         { t.began = true }
+func (t *testAPI) BeginEdit(int)                     {}
+func (t *testAPI) BeginDelete(int)                   {}
+func (t *testAPI) Connect(Profile) tea.Cmd           { return nil }
+func (t *testAPI) HandleConnectResult(ConnectResult) {}
+func (t *testAPI) DisconnectActive()                 {}
+func (t *testAPI) ResizeTraces(int, int)             {}
+func (t *testAPI) ResetElemPos()                     {}
+func (t *testAPI) SetElemPos(string, int)            {}
+func (t *testAPI) OverlayHelp(view string) string    { return view }
+func (t *testAPI) SetConnecting(string)              {}
+func (t *testAPI) SetConnected(string)               {}
+func (t *testAPI) SetDisconnected(string, string)    {}
+
+func TestAddKeyTriggersBeginAdd(t *testing.T) {
+	mgr := NewConnectionsModel()
+	api := &testAPI{mgr: &mgr}
+	nav := &testNav{}
+	c := NewComponent(nav, api)
+	c.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	if !api.began {
+		t.Fatalf("expected BeginAdd called")
+	}
+	if nav.mode != constants.ModeEditConnection {
+		t.Fatalf("expected mode %v, got %v", constants.ModeEditConnection, nav.mode)
+	}
+}

--- a/payloads/payloads_component_test.go
+++ b/payloads/payloads_component_test.go
@@ -1,0 +1,29 @@
+package payloads
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+type testModel struct{ clientMode bool }
+
+func (t *testModel) SetClientMode() tea.Cmd        { t.clientMode = true; return nil }
+func (t *testModel) FocusedID() string             { return "" }
+func (t *testModel) ResetElemPos()                 {}
+func (t *testModel) SetElemPos(id string, pos int) {}
+func (t *testModel) OverlayHelp(s string) string   { return s }
+func (t *testModel) Width() int                    { return 0 }
+
+type testStatus struct{}
+
+func (testStatus) ListenStatus() tea.Cmd { return nil }
+
+func TestEscReturnsClientMode(t *testing.T) {
+	m := &testModel{}
+	p := New(m, testStatus{})
+	p.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if !m.clientMode {
+		t.Fatalf("expected client mode")
+	}
+}

--- a/traces/component_test.go
+++ b/traces/component_test.go
@@ -1,0 +1,53 @@
+package traces
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	connections "github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/constants"
+)
+
+type testAPI struct{ mode constants.AppMode }
+
+func (t *testAPI) StartConfirm(string, string, func() tea.Cmd, func() tea.Cmd, func()) {}
+func (t *testAPI) SetModeClient() tea.Cmd                                              { t.mode = constants.ModeClient; return nil }
+func (t *testAPI) SetModeTracer() tea.Cmd                                              { t.mode = constants.ModeTracer; return nil }
+func (t *testAPI) SetModeEditTrace() tea.Cmd                                           { t.mode = constants.ModeEditTrace; return nil }
+func (t *testAPI) SetModeViewTrace() tea.Cmd                                           { t.mode = constants.ModeViewTrace; return nil }
+func (t *testAPI) SetModeTraceFilter() tea.Cmd                                         { t.mode = constants.ModeTraceFilter; return nil }
+func (t *testAPI) SetFocus(string) tea.Cmd                                             { return nil }
+func (t *testAPI) FocusedID() string                                                   { return "" }
+func (t *testAPI) ResetElemPos()                                                       {}
+func (t *testAPI) SetElemPos(string, int)                                              {}
+func (t *testAPI) OverlayHelp(v string) string                                         { return v }
+func (t *testAPI) Profiles() []connections.Profile                                     { return nil }
+func (t *testAPI) ActiveConnection() string                                            { return "" }
+func (t *testAPI) SubscribedTopics() []string                                          { return nil }
+func (t *testAPI) LogHistory(string, string, string, bool, string)                     {}
+func (t *testAPI) TraceHeight() int                                                    { return 0 }
+func (t *testAPI) SetTraceHeight(int)                                                  {}
+func (t *testAPI) Width() int                                                          { return 80 }
+func (t *testAPI) Height() int                                                         { return 24 }
+func (t *testAPI) NewClient(connections.Profile) (Client, error)                       { return nil, nil }
+
+type noopStore struct{}
+
+func (noopStore) LoadTraces() map[string]TracerConfig                         { return nil }
+func (noopStore) SaveTraces(map[string]TracerConfig) error                    { return nil }
+func (noopStore) AddTrace(TracerConfig) error                                 { return nil }
+func (noopStore) RemoveTrace(string) error                                    { return nil }
+func (noopStore) Messages(string, string) ([]TracerMessage, error)            { return nil, nil }
+func (noopStore) HasData(string, string) (bool, error)                        { return false, nil }
+func (noopStore) ClearData(string, string) error                              { return nil }
+func (noopStore) LoadCounts(string, string, []string) (map[string]int, error) { return nil, nil }
+
+func TestEscSetsClientMode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	api := &testAPI{}
+	c := NewComponent(api, State{}, &noopStore{})
+	c.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if api.mode != constants.ModeClient {
+		t.Fatalf("expected mode %v, got %v", constants.ModeClient, api.mode)
+	}
+}


### PR DESCRIPTION
## Summary
- switch payloads, connections and traces components to map-based key dispatch
- define `KeyAction` type and consolidate key handlers
- add tests exercising key action maps

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689d07b61f008324a07927c054e5e3a9