### PR TITLE
Refactor MQTT client using options pattern

### DIFF
--- a/mqttclient/options.go
+++ b/mqttclient/options.go
@@ -1,0 +1,116 @@
+package mqttclient
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+// ClientOption configures mqtt.ClientOptions.
+type ClientOption func(*mqtt.ClientOptions)
+
+// WithBroker sets the broker URL.
+func WithBroker(url string) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		o.AddBroker(url)
+	}
+}
+
+// WithClientID sets the client ID, optionally adding a random suffix.
+func WithClientID(id string, random bool) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		if random {
+			id = fmt.Sprintf("%s-%d", id, time.Now().UnixNano())
+		}
+		o.SetClientID(id)
+	}
+}
+
+// WithAuth sets the username and password if provided.
+func WithAuth(user, pass string) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		o.SetUsername(user)
+		if pass != "" {
+			o.SetPassword(pass)
+		}
+	}
+}
+
+// WithVersion sets the MQTT protocol version if specified.
+func WithVersion(ver string) (ClientOption, error) {
+	if ver == "" {
+		return func(o *mqtt.ClientOptions) {}, nil
+	}
+	v, err := strconv.Atoi(ver)
+	if err != nil {
+		return nil, fmt.Errorf("invalid MQTT version %q: %w", ver, err)
+	}
+	return func(o *mqtt.ClientOptions) {
+		if v != 0 {
+			o.SetProtocolVersion(uint(v))
+		}
+	}, nil
+}
+
+// WithTimeouts configures connect timeout and keepalive.
+func WithTimeouts(connectTimeout, keepAlive int) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		if connectTimeout > 0 {
+			o.SetConnectTimeout(time.Duration(connectTimeout) * time.Second)
+		}
+		if keepAlive > 0 {
+			o.SetKeepAlive(time.Duration(keepAlive) * time.Second)
+		}
+	}
+}
+
+// WithSession sets auto reconnect and clean session flags.
+func WithSession(autoReconnect, cleanStart bool) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		o.SetAutoReconnect(autoReconnect)
+		o.SetCleanSession(cleanStart)
+	}
+}
+
+// WithWill sets the last will message if enabled.
+func WithWill(enabled bool, topic, payload string, qos int, retain bool) ClientOption {
+	return func(o *mqtt.ClientOptions) {
+		if enabled && topic != "" {
+			o.SetWill(topic, payload, byte(qos), retain)
+		}
+	}
+}
+
+// WithTLS applies TLS configuration when SSL is enabled.
+func WithTLS(ssl bool, skipVerify bool, caCertPath, clientCertPath, clientKeyPath string) (ClientOption, error) {
+	if !ssl {
+		return func(o *mqtt.ClientOptions) {}, nil
+	}
+	tlsCfg := &tls.Config{InsecureSkipVerify: skipVerify}
+	if caCertPath != "" {
+		caData, err := os.ReadFile(caCertPath)
+		if err != nil {
+			return nil, fmt.Errorf("read CA cert: %w", err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caData) {
+			return nil, fmt.Errorf("invalid CA cert")
+		}
+		tlsCfg.RootCAs = pool
+	}
+	if clientCertPath != "" && clientKeyPath != "" {
+		cert, err := tls.LoadX509KeyPair(clientCertPath, clientKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("load client cert: %w", err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+	return func(o *mqtt.ClientOptions) {
+		o.SetTLSConfig(tlsCfg)
+	}, nil
+}

--- a/mqttclient_test.go
+++ b/mqttclient_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+	mqttoptions "github.com/marang/emqutiti/mqttclient"
 )
 
 type fakeToken struct {
@@ -48,5 +49,37 @@ func TestWaitTokenTimeout(t *testing.T) {
 	err := waitToken(tok, to, "subscribe")
 	if err == nil || !strings.Contains(err.Error(), "subscribe timeout") {
 		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestWithAuthOption(t *testing.T) {
+	opts := mqtt.NewClientOptions()
+	mqttoptions.WithAuth("user", "pass")(opts)
+	if opts.Username != "user" || opts.Password != "pass" {
+		t.Fatalf("auth option not applied")
+	}
+}
+
+func TestWithAuthDefaults(t *testing.T) {
+	opts := mqtt.NewClientOptions()
+	mqttoptions.WithAuth("", "")(opts)
+	if opts.Username != "" || opts.Password != "" {
+		t.Fatalf("expected defaults for username and password")
+	}
+}
+
+func TestWithTimeouts(t *testing.T) {
+	opts := mqtt.NewClientOptions()
+	mqttoptions.WithTimeouts(10, 20)(opts)
+	if opts.ConnectTimeout != 10*time.Second || opts.KeepAlive != 20 {
+		t.Fatalf("timeouts not applied: got %v and %d", opts.ConnectTimeout, opts.KeepAlive)
+	}
+}
+
+func TestWithTimeoutsDefaults(t *testing.T) {
+	opts := mqtt.NewClientOptions()
+	mqttoptions.WithTimeouts(0, 0)(opts)
+	if opts.ConnectTimeout != 30*time.Second || opts.KeepAlive != 30 {
+		t.Fatalf("expected default timeouts, got %v and %d", opts.ConnectTimeout, opts.KeepAlive)
 	}
 }


### PR DESCRIPTION
## Summary
- add ClientOption and helper functions to configure MQTT client
- refactor `NewMQTTClient` to build and apply options from connection profiles
- test option helpers for auth and timeout behavior

## Testing
- `go vet ./...`
- `go test ./...` *(fails: importer TestSettingsRoundTrip)*


------
https://chatgpt.com/codex/tasks/task_e_689d0d098ee083248f68856d6508ab44