### PR TITLE
build: strip debug info and document flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROTOC ?= protoc
 .PHONY: build test vet proto cast
 
 build:
-	go build -o emqutiti ./cmd/emqutiti
+	go build -trimpath -ldflags="-s -w" -o emqutiti ./cmd/emqutiti
 
 vet:
 	go vet ./...

--- a/README.md
+++ b/README.md
@@ -180,6 +180,14 @@ Additional notes for repository contributors are available in [AGENTS.md](AGENTS
 
 ## Development
 
+### Building
+
+`make build` compiles the `emqutiti` binary using:
+
+```bash
+go build -trimpath -ldflags="-s -w" -o emqutiti ./cmd/emqutiti
+```
+
 ### Common tasks
 
 - `make build` – compile the `emqutiti` binary


### PR DESCRIPTION
## Summary
- trim paths and strip symbols in `make build`
- document new build flags in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d0da32cf083249e40baa733373b2c