### PR TITLE
Ensure cast Docker image uses executable binary

### DIFF
--- a/docs/scripts/Dockerfile.cast
+++ b/docs/scripts/Dockerfile.cast
@@ -13,7 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Build emqutiti
 WORKDIR /app
 COPY . .
-RUN go build -o emqutiti .
+RUN rm -f emqutiti && \
+    go build -o emqutiti . && \
+    chmod +x emqutiti
 
 # Prepare default config
 # RUN mkdir -p /root/.config/emqutiti && \


### PR DESCRIPTION
## Summary
- rebuild demo Docker image after removing any leftover `emqutiti` binary and set execute bit

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a609c150a0832487d69c3e16977307