### PR TITLE
Confirm disconnect before returning to broker manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Tips:
 | Manage topics | `Ctrl+T` |
 | Manage traces | `Ctrl+R` |
 | Open broker manager | `Ctrl+B` |
-| Disconnect from broker | `Ctrl+X` |
+| Disconnect from broker after confirmation and offer to reconnect immediately or return to the broker manager | `Ctrl+X` |
 | Publish message | `Ctrl+S` |
 | Publish retained message | `Ctrl+E` |
 | Open log viewer | `Ctrl+L` |
@@ -143,7 +143,7 @@ Tips:
 
 #### Broker Manager
 
-- `x` disconnects the selected profile
+- `Ctrl+X` disconnects the selected profile
 - `Ctrl+O` toggles the default profile
 
 #### History View

--- a/help/help.md
+++ b/help/help.md
@@ -9,7 +9,7 @@
 | Ctrl+T | Manage topics |
 | Ctrl+R | Manage traces |
 | Ctrl+B | Open broker manager |
-| Ctrl+X | Disconnect from broker |
+| Ctrl+X | Disconnect from broker after confirmation; offers immediate reconnect or opens broker manager |
 | Ctrl+S | Publish message |
 | Ctrl+E | Publish retained message |
 | Ctrl+L | Open log viewer |
@@ -29,7 +29,7 @@
 | Key | Action |
 | --- | ------ |
 | Enter | Connect or open client |
-| x | Disconnect selected profile |
+| Ctrl+X | Disconnect selected profile |
 | a | Add profile |
 | e | Edit selected profile |
 | Delete | Remove selected profile |

--- a/update_client.go
+++ b/update_client.go
@@ -88,6 +88,25 @@ func (m *model) handleClientMsg(msg tea.Msg) (tea.Cmd, bool) {
 		return m.handleStatusMessage(t), true
 	case MQTTMessage:
 		return m.handleMQTTMessage(t), true
+	case reconnectPromptMsg:
+		m.SetMode(constants.ModeConnections)
+		var p connections.Profile
+		for _, pr := range m.connections.Manager.Profiles {
+			if pr.Name == string(t) {
+				p = pr
+				break
+			}
+		}
+		if p.Name != "" {
+			m.StartConfirm(
+				fmt.Sprintf("Reconnect to '%s'? [y/n]", p.Name),
+				"",
+				nil,
+				func() tea.Cmd { return m.Connect(p) },
+				nil,
+			)
+		}
+		return nil, true
 	case tea.KeyMsg:
 		return HandleClientKey(m, t), false
 	case tea.MouseMsg:


### PR DESCRIPTION
## Summary
- Prompt for confirmation before disconnecting and route users back to the broker manager with an optional reconnect dialog
- Switch mode to the broker manager after a disconnect, offering to reconnect immediately
- Document that `Ctrl+X` disconnects with confirmation and enables quick reconnection

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bbe98aa6dc8324934d6cffce2d341c