### PR TITLE
Move topic input above topics list

### DIFF
--- a/view_client.go
+++ b/view_client.go
@@ -43,13 +43,13 @@ func (m *model) viewClient() string {
 		}
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, topicBox, topicsBox, messageBox, messagesBox)
 	y := 1
 
-	m.ui.elemPos[idTopics] = y
-	y += lipgloss.Height(topicsBox)
 	m.ui.elemPos[idTopic] = y
 	y += lipgloss.Height(topicBox)
+	m.ui.elemPos[idTopics] = y
+	y += lipgloss.Height(topicsBox)
 	m.ui.elemPos[idMessage] = y
 	y += lipgloss.Height(messageBox)
 	m.ui.elemPos[idHistory] = y


### PR DESCRIPTION
## Summary
- Render the topic input box before the topics list in the client view

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfc5c6044832499c3aa127f0c3c20