### PR TITLE
Move topic input above topics list

### DIFF
--- a/client_topics_selection_test.go
+++ b/client_topics_selection_test.go
@@ -12,16 +12,17 @@ func TestTopicSelectionPersistsAcrossFocus(t *testing.T) {
 	m.topics.SetSelected(1)
 
 	// Simulate focus cycling forward to topics
-	m.focus.Set(4) // idHelp index so tab wraps to idTopics
+	m.focus.Set(4) // idHelp index so tab wraps to idTopic then idTopics
 	m.ui.focusIndex = 4
+	m.handleTabKey()
 	m.handleTabKey()
 	if m.topics.Selected() != 1 {
 		t.Fatalf("expected selected index 1 after Tab, got %d", m.topics.Selected())
 	}
 
 	// Simulate focus cycling backward to topics
-	m.focus.Set(1) // idTopic index so shift+tab goes to idTopics
-	m.ui.focusIndex = 1
+	m.focus.Set(2) // idMessage index so shift+tab goes to idTopics
+	m.ui.focusIndex = 2
 	m.handleShiftTabKey()
 	if m.topics.Selected() != 1 {
 		t.Fatalf("expected selected index 1 after Shift+Tab, got %d", m.topics.Selected())
@@ -43,8 +44,8 @@ func TestToggleTopicKeepsSelection(t *testing.T) {
 		{Name: "c", Subscribed: true},
 	}
 	m.topics.SetSelected(2)
-	m.focus.Set(0)
-	m.ui.focusIndex = 0
+	m.focus.Set(1)
+	m.ui.focusIndex = 1
 	m.handleEnterKey()
 	if m.topics.Items[m.topics.Selected()].Name != "c" {
 		t.Fatalf("expected to stay on topic 'c', got %q", m.topics.Items[m.topics.Selected()].Name)
@@ -59,8 +60,8 @@ func TestTogglePublishKeepsSelection(t *testing.T) {
 		{Name: "c", Subscribed: true},
 	}
 	m.topics.SetSelected(2)
-	m.focus.Set(0)
-	m.ui.focusIndex = 0
+	m.focus.Set(1)
+	m.ui.focusIndex = 1
 	m.handleTogglePublishKey()
 	if m.topics.Items[m.topics.Selected()].Name != "c" {
 		t.Fatalf("expected to stay on topic 'c', got %q", m.topics.Items[m.topics.Selected()].Name)

--- a/focus_test.go
+++ b/focus_test.go
@@ -17,16 +17,19 @@ func TestSetFocusMessage(t *testing.T) {
 	}
 }
 
-// Test that pressing Tab cycles focus from topic to message
-// Test that pressing Tab cycles focus from topics to topic input
-func TestTabCyclesToTopic(t *testing.T) {
+// Test that pressing Tab cycles focus from topic input to topics list
+func TestTabCyclesFromTopicInput(t *testing.T) {
 	m, _ := initialModel(nil)
-	if m.focus.Index() != 0 {
-		t.Fatalf("initial focus index should be 0")
+	if m.focus.Index() != 1 {
+		t.Fatalf("initial focus index should be 1")
+	}
+	m.SetFocus(idTopic)
+	if !m.topics.Input.Focused() {
+		t.Fatalf("topic input should be focused after SetFocus")
 	}
 	m.focus.Next()
-	if !m.topics.Input.Focused() {
-		t.Fatalf("topic input should be focused after tab")
+	if m.topics.Input.Focused() {
+		t.Fatalf("topic input should be blurred after tab")
 	}
 	if m.focus.Index() != 1 {
 		t.Fatalf("focus index should be 1 after tab, got %d", m.focus.Index())

--- a/model_base.go
+++ b/model_base.go
@@ -20,7 +20,7 @@ const (
 )
 
 var focusByMode = map[constants.AppMode][]string{
-	constants.ModeClient:         {idTopics, idTopic, idMessage, idHistory, idHelp},
+	constants.ModeClient:         {idTopic, idTopics, idMessage, idHistory, idHelp},
 	constants.ModeConnections:    {constants.IDConnList, idHelp},
 	constants.ModeEditConnection: {constants.IDConnList, idHelp},
 	constants.ModeConfirmDelete:  {},

--- a/model_init.go
+++ b/model_init.go
@@ -83,6 +83,7 @@ func initialModel(conns *connections.Connections) (*model, error) {
 	m.payloads = payloads.New(m, &m.connections)
 	m.traces = traces.NewComponent(m, tr, m.tracesStore())
 	initComponents(m, order, connComp)
+	m.SetFocus(idTopics)
 	if err := initImporter(m); err != nil {
 		return nil, err
 	}

--- a/update_helpers_test.go
+++ b/update_helpers_test.go
@@ -18,13 +18,14 @@ func TestCycleFocusNext(t *testing.T) {
 	if _, ok := m.cycleFocus(focusNext); !ok {
 		t.Fatalf("cycleFocus next should return true")
 	}
-	if m.focus.Index() != 1 {
-		t.Fatalf("focus index got %d, want 1", m.focus.Index())
+	if m.focus.Index() != 2 {
+		t.Fatalf("focus index got %d, want 2", m.focus.Index())
 	}
 }
 
 func TestCycleFocusPrevWraps(t *testing.T) {
 	m, _ := initialModel(nil)
+	m.SetFocus(idTopic)
 	if _, ok := m.cycleFocus(focusPrev); !ok {
 		t.Fatalf("cycleFocus prev should return true")
 	}

--- a/view_client.go
+++ b/view_client.go
@@ -43,13 +43,13 @@ func (m *model) viewClient() string {
 		}
 	}
 
-	content := lipgloss.JoinVertical(lipgloss.Left, topicsBox, topicBox, messageBox, messagesBox)
+	content := lipgloss.JoinVertical(lipgloss.Left, topicBox, topicsBox, messageBox, messagesBox)
 	y := 1
 
-	m.ui.elemPos[idTopics] = y
-	y += lipgloss.Height(topicsBox)
 	m.ui.elemPos[idTopic] = y
 	y += lipgloss.Height(topicBox)
+	m.ui.elemPos[idTopics] = y
+	y += lipgloss.Height(topicsBox)
 	m.ui.elemPos[idMessage] = y
 	y += lipgloss.Height(messageBox)
 	m.ui.elemPos[idHistory] = y


### PR DESCRIPTION
## Summary
- Cycle focus from topic input to topics list before message and history
- Keep topics list initially focused despite reorder
- Adjust unit tests for new focus order

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bbfc5c6044832499c3aa127f0c3c20