### PR TITLE
Persist per-profile layout heights

### DIFF
--- a/client_keys.go
+++ b/client_keys.go
@@ -78,7 +78,13 @@ func (m *model) HandleClientKey(msg tea.KeyMsg) tea.Cmd {
 
 // handleQuitKey saves current state and quits the application.
 func (m *model) handleQuitKey() tea.Cmd {
-	m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
+	m.connections.SaveCurrent(
+		m.topics.Snapshot(),
+		m.payloads.Snapshot(),
+		m.layout.message.height,
+		m.layout.topics.height,
+		m.layout.history.height,
+	)
 	m.traces.SavePlannedTraces()
 	return tea.Quit
 }

--- a/client_keys_layout.go
+++ b/client_keys_layout.go
@@ -111,7 +111,13 @@ func (m *model) handleModeSwitchKey(msg tea.KeyMsg) tea.Cmd {
 			m.history.Append("", err.Error(), "log", false, err.Error())
 		}
 		m.connections.RefreshConnectionItems()
-		m.connections.SaveCurrent(m.topics.Snapshot(), m.payloads.Snapshot())
+		m.connections.SaveCurrent(
+			m.topics.Snapshot(),
+			m.payloads.Snapshot(),
+			m.layout.message.height,
+			m.layout.topics.height,
+			m.layout.history.height,
+		)
 		m.traces.SavePlannedTraces()
 		return m.SetMode(constants.ModeConnections)
 	case constants.KeyCtrlT:

--- a/connections/component.go
+++ b/connections/component.go
@@ -80,12 +80,19 @@ func (c *State) RefreshConnectionItems() {
 	c.Manager.refreshList()
 }
 
-// SaveCurrent persists topics and payloads for the active connection.
-func (c *State) SaveCurrent(topics []TopicSnapshot, payloads []PayloadSnapshot) {
+// SaveCurrent persists topics, payloads, and layout heights for the active
+// connection.
+func (c *State) SaveCurrent(topics []TopicSnapshot, payloads []PayloadSnapshot, messageHeight, topicsHeight, historyHeight int) {
 	if c.Active == "" {
 		return
 	}
-	c.Saved[c.Active] = ConnectionSnapshot{Topics: topics, Payloads: payloads}
+	c.Saved[c.Active] = ConnectionSnapshot{
+		Topics:        topics,
+		Payloads:      payloads,
+		MessageHeight: messageHeight,
+		TopicsHeight:  topicsHeight,
+		HistoryHeight: historyHeight,
+	}
 	if err := SaveState(c.Saved); err != nil {
 		log.Printf("Failed to save connection state: %v", err)
 	}

--- a/connections/state.go
+++ b/connections/state.go
@@ -8,10 +8,14 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-// ConnectionSnapshot holds topics and payloads for a connection in config.toml.
+// ConnectionSnapshot holds topics, payloads, and layout heights for a
+// connection in config.toml.
 type ConnectionSnapshot struct {
-	Topics   []TopicSnapshot   `toml:"topics"`
-	Payloads []PayloadSnapshot `toml:"payloads"`
+	Topics        []TopicSnapshot   `toml:"topics"`
+	Payloads      []PayloadSnapshot `toml:"payloads"`
+	MessageHeight int               `toml:"message_height,omitempty"`
+	TopicsHeight  int               `toml:"topics_height,omitempty"`
+	HistoryHeight int               `toml:"history_height,omitempty"`
 }
 
 // userConfig represents the structure stored in config.toml.

--- a/connections_api_impl.go
+++ b/connections_api_impl.go
@@ -117,6 +117,7 @@ func (m *model) HandleConnectResult(msg connections.ConnectResult) {
 	ts, ps := m.connections.RestoreState(profile.Name)
 	m.topics.SetSnapshot(ts)
 	m.payloads.SetSnapshot(ps)
+	m.applySavedLayout(profile.Name)
 	m.topics.SortTopics()
 	m.topics.RebuildActiveTopicList()
 	m.SubscribeActiveTopics()


### PR DESCRIPTION
## Summary
- store per-connection message, topics, and history heights in saved connection snapshots and write them from SaveCurrent
- apply saved layout heights when creating the UI and after connecting so panes honor prior sizing

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d7fe549df4832489d6c63edcbf1c1e