### PR TITLE
Add integration test for tracer using live MQTT broker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.8.0
 	github.com/eclipse/paho.mqtt.golang v1.5.0
 	github.com/mattn/go-runewidth v0.0.16
+	github.com/mochi-co/mqtt v1.3.2
 	github.com/zalando/go-keyring v0.2.6
 	google.golang.org/grpc v1.74.2
 	google.golang.org/protobuf v1.36.6
@@ -50,6 +51,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
+	github.com/rs/xid v1.4.0 // indirect
 	github.com/sahilm/fuzzy v0.1.1 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -83,6 +83,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/jinzhu/copier v0.3.5 h1:GlvfUwHk62RokgqVNvYsku0TATCF7bAHVwEXoBh3iJg=
+github.com/jinzhu/copier v0.3.5/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
@@ -98,6 +100,8 @@ github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6T
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
+github.com/mochi-co/mqtt v1.3.2 h1:cRqBjKdL1yCEWkz/eHWtaN/ZSpkMpK66+biZnrLrHC8=
+github.com/mochi-co/mqtt v1.3.2/go.mod h1:o0lhQFWL8QtR1+8a9JZmbY8FhZ89MF8vGOGHJNFbCB8=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6/go.mod h1:CJlz5H+gyd6CUWT45Oy4q24RdLyn7Md9Vj2/ldJBSIo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
@@ -112,6 +116,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
 github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/traces/runtime_integration_test.go
+++ b/traces/runtime_integration_test.go
@@ -1,0 +1,157 @@
+package traces
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	connections "github.com/marang/emqutiti/connections"
+	"github.com/marang/emqutiti/proxy"
+	"github.com/mochi-co/mqtt/server"
+	"github.com/mochi-co/mqtt/server/listeners"
+)
+
+func TestTraceWithLiveBroker(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	prevProxy := proxyAddr
+	p, err := proxy.StartProxy("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	SetProxyAddr(p.Addr())
+	t.Cleanup(func() {
+		p.Stop()
+		SetProxyAddr(prevProxy)
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close temp listener: %v", err)
+	}
+
+	broker := server.New()
+	tcp := listeners.NewTCP("test", addr)
+	if err := broker.AddListener(tcp, nil); err != nil {
+		t.Fatalf("add listener: %v", err)
+	}
+	if err := broker.Serve(); err != nil {
+		t.Fatalf("serve broker: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := broker.Close(); err != nil {
+			t.Logf("close broker: %v", err)
+		}
+	})
+
+	host, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+
+	profile := connections.Profile{
+		Name:       "integration",
+		Schema:     "tcp",
+		Host:       host,
+		Port:       port,
+		ClientID:   fmt.Sprintf("trace-client-%d", time.Now().UnixNano()),
+		CleanStart: true,
+	}
+
+	client, err := newMQTTClient(profile)
+	if err != nil {
+		t.Fatalf("new mqtt client: %v", err)
+	}
+	defer client.Disconnect()
+
+	key := fmt.Sprintf("trace-%d", time.Now().UnixNano())
+	topic := "test/trace"
+	cfg := TracerConfig{
+		Profile: profile.Name,
+		Topics:  []string{topic},
+		Start:   time.Now().Add(-100 * time.Millisecond),
+		Key:     key,
+	}
+	if err := tracerClearData(cfg.Profile, cfg.Key); err != nil {
+		t.Fatalf("clear data: %v", err)
+	}
+
+	tracer := newTracer(cfg, client)
+	if err := tracer.Start(); err != nil {
+		t.Fatalf("start trace: %v", err)
+	}
+	t.Cleanup(tracer.Stop)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !tracer.Running() {
+		if time.Now().After(deadline) {
+			t.Fatalf("tracer never started")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	pubOpts := mqtt.NewClientOptions()
+	pubOpts.AddBroker(profile.BrokerURL())
+	pubOpts.SetClientID(fmt.Sprintf("publisher-%d", time.Now().UnixNano()))
+	pubOpts.SetConnectTimeout(2 * time.Second)
+	publisher := mqtt.NewClient(pubOpts)
+	if token := publisher.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatalf("publisher connect: %v", token.Error())
+	}
+	defer publisher.Disconnect(250)
+
+	payload := "integration payload"
+	token := publisher.Publish(topic, 0, false, payload)
+	token.Wait()
+	if err := token.Error(); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	waitDeadline := time.Now().Add(5 * time.Second)
+	for {
+		counts := tracer.Counts()
+		if counts[topic] > 0 {
+			break
+		}
+		if time.Now().After(waitDeadline) {
+			t.Fatalf("no messages captured")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	tracer.Stop()
+
+	msgs, err := tracer.Messages()
+	if err != nil {
+		t.Fatalf("messages: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatalf("expected at least one message")
+	}
+	found := false
+	for _, m := range msgs {
+		if m.Topic == topic && m.Payload == payload {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected payload %q on topic %q", payload, topic)
+	}
+}


### PR DESCRIPTION
## Summary
- add a trace integration test that spins up a mochi MQTT broker and ensures messages are captured through the tracer runtime
- add the mochi MQTT server dependency needed for the live broker test

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68e2842f2e5883248920e04e51e5bb4b