### PR TITLE
Prompt for trace profile when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ General
 
 - `-i, --import FILE` Launch import wizard with optional file path (e.g., `-i data.csv`)
 - `-p, --profile NAME` Connection profile name to use (e.g., `-p local`)
+- `-l, --list-profiles` List available connection profiles and exit
 
 Trace
 
@@ -69,6 +70,7 @@ Trace
 - `--topics LIST` Comma-separated topics to trace (e.g., `--topics "sensors/#"`)
 - `--start TIME` Optional RFC3339 start time (e.g., `--start "2025-08-05T11:47:00Z"`)
 - `--end TIME` Optional RFC3339 end time (e.g., `--end "2025-08-05T11:49:00Z"`)
+- omit `-p/--profile` with `--trace` to choose a connection profile interactively before the trace starts
 
 Times must be RFC3339 formatted.
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -8,13 +8,14 @@ import (
 )
 
 type AppConfig struct {
-	ImportFile  string
-	ProfileName string
-	TraceKey    string
-	TraceTopics string
-	TraceStart  string
-	TraceEnd    string
-	Timeout     time.Duration
+	ImportFile   string
+	ProfileName  string
+	TraceKey     string
+	TraceTopics  string
+	TraceStart   string
+	TraceEnd     string
+	Timeout      time.Duration
+	ListProfiles bool
 }
 
 func ParseFlags() AppConfig {
@@ -29,12 +30,15 @@ func ParseFlags() AppConfig {
 	fs.StringVar(&cfg.TraceStart, "start", "", "Optional RFC3339 trace start time")
 	fs.StringVar(&cfg.TraceEnd, "end", "", "Optional RFC3339 trace end time")
 	fs.DurationVar(&cfg.Timeout, "timeout", 0, "Optional overall runtime limit (e.g., 30s)")
+	fs.BoolVar(&cfg.ListProfiles, "list-profiles", false, "List available connection profiles and exit")
+	fs.BoolVar(&cfg.ListProfiles, "l", false, "(shorthand)")
 	fs.Usage = func() {
 		w := fs.Output()
 		fmt.Fprintf(w, "Usage: %s [flags]\n\n", os.Args[0])
 		fmt.Fprintln(w, "General:")
 		fmt.Fprintln(w, "  -i, --import FILE     Launch import wizard with optional file path (e.g., -i data.csv)")
 		fmt.Fprintln(w, "  -p, --profile NAME    Connection profile name to use (e.g., -p local)")
+		fmt.Fprintln(w, "  -l, --list-profiles   List available connection profiles and exit")
 		fmt.Fprintln(w, "")
 		fmt.Fprintln(w, "Trace:")
 		fmt.Fprintln(w, "      --trace KEY       Trace key name to store messages (e.g., --trace run1)")

--- a/help/help.md
+++ b/help/help.md
@@ -88,6 +88,7 @@ Retained messages are labeled "(retained)".
 
 - `-i, --import FILE` Launch CSV import wizard with optional file path (e.g., `-i data.csv`)
 - `-p, --profile NAME` Connection profile name to use (e.g., `-p local`)
+- `-l, --list-profiles` List available connection profiles and exit
 
 **Trace**
 
@@ -95,3 +96,4 @@ Retained messages are labeled "(retained)".
 - `--topics LIST` Comma-separated topics to trace (e.g., `--topics "sensors/#"`)
 - `--start TIME` Optional RFC3339 start time (e.g., `--start "2025-08-05T11:47:00Z"`)
 - `--end TIME` Optional RFC3339 end time (e.g., `--end "2025-08-05T11:49:00Z"`)
+- Omit `-p/--profile` when tracing to pick a connection interactively before starting


### PR DESCRIPTION
## Summary
- prompt for a connection profile when starting a trace without -p/--profile
- add CLI docs noting the interactive trace selection option
- cover the new selection helper and trace flow with unit tests

## Testing
- go test ./...
- go vet ./...


------
https://chatgpt.com/codex/tasks/task_e_68e23e1a4db08324bd026a2861cdff3b