### PR TITLE
Fix AUR workflow known hosts setup

### DIFF
--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -52,10 +52,11 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.AUR_PRIVATE_KEY }}
 
-      - name: Trust AUR host key (system-wide)
+      - name: Trust AUR host key
         run: |
-          install -m 644 -D /dev/null /etc/ssh/ssh_known_hosts
-          ssh-keyscan -t ed25519 aur.archlinux.org >> /etc/ssh/ssh_known_hosts
+          install -m 700 -d ~/.ssh
+          ssh-keyscan -t ed25519 aur.archlinux.org >> ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
 
       - name: Clone AUR repo
         env:


### PR DESCRIPTION
## Summary
- adjust the AUR workflow to store the host key in the runner's SSH config directory instead of /etc
- ensure the directory exists and permissions are correct before adding aur.archlinux.org

## Testing
- go test ./... *(fails: command hung in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2992e9bd483249e25d9cecd4e4413